### PR TITLE
Add docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Mozilla Community Portal 
+# Mozilla Community Portal
 
-This repo will contain all the theme files for the new Mozilla community portal.  
+This repo will contain all the theme files for the new Mozilla community portal.
 
 ## Requirements
 * Node version 8.9.3
-* Running instance of Wordpress.  For development and deployment to wpengine purposes we are currently using wpe-devkit (https://wpengine.com/devkit/).  
-* All the required wordpress plugins. (buddypress v4.4.0, eventmanager v5.9.5, advanced custom fields v5.8.2) 
+* Running instance of Wordpress. For development and deployment to wpengine purposes we are currently using wpe-devkit (https://wpengine.com/devkit/).
+* All the required wordpress plugins. (buddypress v4.4.0, events manager v5.9.5, advanced custom fields v5.8.2)
 
 ## Getting Started
-1. Clone the repo into the wp-content/themes folder of the wordpress instance.  
-2. Install all the node dependences by running the following command ```npm install```
+1. Clone the repo into the wp-content/themes folder of the wordpress instance.
+2. Install all the node dependencies by running the following command ```npm install```
 
 ### Compile
 To compile the sass files run ```npm run compile```
@@ -22,3 +22,25 @@ To live update the styles run ```npm run watch```
 
 ### Activate
 To activate the theme through the Wordpress admin panel.
+
+## Getting started with docker-compose
+
+### Requirements
+
+* Node version 8.9.3
+* Docker and docker-compose
+* No need to have a wordpress instance running, docker-compose will take care of that
+
+### Start Wordpress instance
+
+To start the necessary docker containers (Wordpress and database) run ```docker-compose up```.
+
+### Set up Wordpress and BuddyPress
+
+Once the containers are started, head to http://localhost:8000 and set up your Wordpress instance. Additionally install and activate the required plugins through Wordpress' interface directly.
+
+Once this is done, you can run through the `Getting started` section above, but without cloning the repository (as docker-compose linked the file here into Wordpress' themes folder). This is only needed if you want to change any code.
+
+### Stopping the Wordpress containers
+
+To stop the containers, run ```docker-compose down```. This will delete all the containers, but it will preserve your database so these changes do not get lost.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.3'
+
+services:
+  db:
+    image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: somewordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+
+  wordpress:
+    depends_on:
+      - db
+    image: wordpress:latest
+    ports:
+      - "8000:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - .:/var/www/html/wp-content/themes/communityportal/
+
+volumes:
+    db_data: {}


### PR DESCRIPTION
This adds a docker-compose file to set up Wordpress and instructions on how to set up the instance.

However, when running this, the CSS does not get properly applied for everything, is there something that additionally needs to be done? I don't see any obvious errors in the dev tools console (apart from the font being blocked by Firefox for my case, but that shouldn't matter too much).

<img width="1680" alt="Screenshot 2019-11-02 at 17 56 17" src="https://user-images.githubusercontent.com/330324/68074563-4bc99500-fd94-11e9-86af-7e49ffd61ab0.png">
