### PR TITLE
Feature/moz 222 rename group privacy to verified

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,7 @@ add_action('get_header', 'remove_admin_login_header');
 // Native Wordpress Actions
 add_action('init', 'mozilla_custom_menu');
 add_action('wp_enqueue_scripts', 'mozilla_init_scripts');
+add_action('admin_enqueue_scripts', 'mozilla_init_admin_scripts');
 
 // Ajax Calls
 add_action('wp_ajax_nopriv_upload_group_image', 'mozilla_upload_image');
@@ -307,6 +308,16 @@ function mozilla_add_active_page($classes, $item) {
     }
 
     return $classes;
+}
+
+function mozilla_init_admin_scripts() {
+    $screen = get_current_screen();
+
+    if(strtolower($screen->id) === 'toplevel_page_bp-groups') {
+        wp_enqueue_script('groups', get_stylesheet_directory_uri()."/js/admin.js", array('jquery'));
+    }
+
+
 }
 
 function mozilla_init_scripts() {

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,4 +7,25 @@ jQuery(function(){
 
     jQuery("label[for='bp-group-status-public']").html($public_input).append('Verified');
     jQuery("label[for='bp-group-status-private']").html($private_input).append('Unverified');
+
+
+    jQuery("td.column-status").each(function(index, ele) {
+        var $ele = jQuery(ele);
+
+        if($ele.data('colname') == 'Status') {
+            if($ele.text() === 'Private') {
+                $ele.text('Unverified');
+            }
+            if($ele.text() === 'Public') {
+                $ele.text('Verified');
+            }
+        }
+    });
+
+    var $public_count = jQuery('li.public').find('.count');
+    var $private_count = jQuery('li.private').find('.count');
+    
+    jQuery('li.public').find('a').insertBefore($public_count.insertBefore('Verified '));
+    jQuery('li.private').find('a').insertBefore($private_count.insertBefore('Unverified'));
+
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,13 @@
+jQuery(function(){
+
+    var $public_input = jQuery('#bp-group-status-public');
+    var $private_input = jQuery('#bp-group-status-private');
+
+    jQuery('#bp-groups-settings-section-status').find('legend').text('Group Status');
+
+    jQuery("label[for='bp-group-status-public']").html($public_input).append('Verified');
+    jQuery("label[for='bp-group-status-private']").html($private_input).append('Unverified');
+
+
+
+});

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,7 +7,4 @@ jQuery(function(){
 
     jQuery("label[for='bp-group-status-public']").html($public_input).append('Verified');
     jQuery("label[for='bp-group-status-private']").html($private_input).append('Unverified');
-
-
-
 });


### PR DESCRIPTION
Changed the labels for group status in group admin page for community managers

![Screen Shot 2019-11-08 at 10 48 20 AM](https://user-images.githubusercontent.com/2521244/68489541-4d241300-0215-11ea-9120-9a2cded99348.png)

![Screen Shot 2019-11-08 at 10 16 45 AM](https://user-images.githubusercontent.com/2521244/68489551-5319f400-0215-11ea-86c1-a24630dd49a0.png)
