### PR TITLE
Fix/moz 230 private events

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1013,4 +1013,7 @@ function mozilla_menu_class($classes, $item, $args) {
     return $classes;
 }
 
+
+remove_action('em_event_save','bp_em_group_event_save',1,2);
+
 ?>

--- a/plugins/events-manager/templates/my-bookings.php
+++ b/plugins/events-manager/templates/my-bookings.php
@@ -4,9 +4,6 @@
     if( is_user_logged_in()):
       $user_id = get_current_user_id();
       $EM_Person = new EM_Person($user_id);
-      $bookingArgs = array(
-        'search' => 're',
-      );
       $bookings = EM_Events::get($bookingArgs);
       $EM_Bookings = $EM_Person->get_bookings();
 


### PR DESCRIPTION
I found the function in the plugin that sets group events to private and removed the action in the theme functions.php. It shouldn't break any of the functionality you've written to check for private events, as it just means no events should be saved as private moving forward