### PR TITLE
Added campaigns and activity custom post types

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -310,6 +310,39 @@ function mozilla_init() {
         }
     }
 
+    // Create Activities
+    $labels = Array(
+        'name'              =>  __('Activities'),
+        'singular_name'     =>  __('Activity')
+    );
+
+    $args = Array(
+        'labels'             => $labels,
+        'public'             => true,
+        'show_in_menu'       => true,
+        'show_in_rest'       => true,
+        'menu_icon'          => 'dashicons-chart-line',
+        'rewrite'            =>  Array('slug'    =>  'activities')
+    );
+
+    register_post_type('activity', $args);
+
+    // Create Campaigns
+    $labels = Array(
+        'name'              =>  __('Campaigns'),
+        'singular_name'     =>  __('Campaign')
+    );
+
+    $args = Array(
+        'labels'             => $labels,
+        'public'             => true,
+        'show_in_menu'       => true,
+        'show_in_rest'       => true,
+        'menu_icon'          => 'dashicons-admin-site-alt3',
+        'rewrite'            =>  Array('slug'    =>  'campaigns')
+    );
+
+    register_post_type('campaign', $args);
 }
 
 function mozilla_add_menu_attrs($attrs, $item, $args) {


### PR DESCRIPTION
This creates the Activity and Campaign custom post types within Wordpress and exposes it to the Gutenberg editor.

No fields have been applied.  You should now see these two post types in the wp-admin side bar menu

![Screen Shot 2019-11-14 at 1 52 46 PM](https://user-images.githubusercontent.com/2521244/68886915-1010c280-06e6-11ea-9c85-0df512cfb4bc.png)
