### PR TITLE
Feature/moz 158 theme settings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1048,8 +1048,19 @@ function mozilla_menu_class($classes, $item, $args) {
 }
 
 function mozilla_theme_settings() {
-    
+    $theme_dir = get_template_directory();
 
+    if($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if(isset($_POST['admin_nonce_field']) && wp_verify_nonce($_REQUEST['admin_nonce_field'], 'protect_content')) {
+            if(isset($_POST['google_analytics_id'])) {
+                update_option('google_analytics_id', sanitize_text_field($_POST['google_analytics_id']));
+            }
+        }
+    }
+
+    $options = wp_load_alloptions();
+    
+    include "{$theme_dir}/templates/settings.php";
 
 }
 

--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,7 @@ add_action('get_header', 'remove_admin_login_header');
 add_action('init', 'mozilla_init');
 add_action('wp_enqueue_scripts', 'mozilla_init_scripts');
 add_action('admin_enqueue_scripts', 'mozilla_init_admin_scripts');
-add_filter('nav_menu_css_class', 'mozilla_menu_class', 10, 4);
+add_action('admin_menu', 'mozilla_add_menu_item');
 
 // Ajax Calls
 add_action('wp_ajax_nopriv_upload_group_image', 'mozilla_upload_image');
@@ -30,12 +30,15 @@ add_action('bp_before_edit_member_page', 'mozilla_update_member', 10, 1);
 
 // Removed cause it was causing styling conflicts
 remove_action('init', 'bp_nouveau_get_container_classes');
+remove_action('em_event_save','bp_em_group_event_save', 1, 2);
+
 
 // Auth0 Actions
 add_action('auth0_user_login', 'mozilla_post_user_creation', 10, 6);
 
 // Filters
 add_filter('nav_menu_link_attributes', 'mozilla_add_menu_attrs', 10, 3);
+add_filter('nav_menu_css_class', 'mozilla_menu_class', 10, 4);
 //add_filter('nav_menu_css_class', 'mozilla_add_active_page' , 10 , 2);
 
 // Events Action
@@ -1044,7 +1047,17 @@ function mozilla_menu_class($classes, $item, $args) {
     return $classes;
 }
 
+function mozilla_theme_settings() {
+    
 
-remove_action('em_event_save','bp_em_group_event_save',1,2);
+
+}
+
+function mozilla_add_menu_item() {
+    add_menu_page('Mozilla Settings', 'Mozilla Settings', 'manage_options', 'theme-panel', 'mozilla_theme_settings', null, 99);
+}
+
+
+
 
 ?>

--- a/header.php
+++ b/header.php
@@ -10,6 +10,9 @@
     } else {
         $avatar = false;
     }
+
+    $google_analytics_id = get_option('google_analytics_id');
+
 ?>
 
 <!DOCTYPE html>
@@ -22,6 +25,16 @@
         <link rel="pingback" href="<?php echo esc_url(get_bloginfo('pingback_url')); ?>">
         <?php endif; ?>
         <?php wp_head(); ?>
+        <?php  if($google_analytics_id && strlen($google_analytics_id) > 0):  ?>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-152873431-1"></script>
+        <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '<?php print $google_analytics_id; ?>');
+        </script>
+        <?php endif; ?>
         <title><?php print get_bloginfo('name'); ?> - <?php print get_bloginfo('description'); ?></title>
     </head>
     <body class="body" <?php body_class(); ?>>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -1,0 +1,17 @@
+<h1>Mozilla Theme Settings</h1>
+<form method="POST" action="/wp-admin/admin.php?page=theme-panel">
+    <?php print wp_nonce_field('protect_content', 'admin_nonce_field'); ?>
+    <table class="form-table" role="presentation">
+        <tbody>
+            <tr>
+                <th scope="row">
+                    <label for="google-analytics-id">Google Analytics ID</label>
+                </th>
+                <td>
+                    <input type="text" id="google-analytics-id" name="google_analytics_id" class="regular-text" value="<?php print $options['google_analytics_id']; ?>" />
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <input type="submit" value="Save Settings" />
+</form>


### PR DESCRIPTION
This PR tackles two tickets.  Sets up the theme settings page and google analytics.  

To test you can go to the wp-admin and there should be an entry for Mozilla Settings on the admin menu on the left side

![Screen Shot 2019-11-19 at 2 05 49 PM](https://user-images.githubusercontent.com/2521244/69177540-b50c1080-0ad5-11ea-81a3-14e2b5df5fde.png)

As of right now the only setting an admin can set is the google analytics id.

![Screen Shot 2019-11-19 at 2 06 10 PM](https://user-images.githubusercontent.com/2521244/69177588-d0771b80-0ad5-11ea-815a-9ba41a66faed.png)

To test you will need to create a new property in google analytics, then get the ID from the javascript code and place it into the field above.  Once saved You can test the tracking by viewing google analytics as you click through the site.