### PR TITLE
Fix/moz 257 profile redirect

### DIFF
--- a/buddypress/members/single/edit.php
+++ b/buddypress/members/single/edit.php
@@ -1,4 +1,4 @@
-<?php if($complete === true): ?>
+<?php if($complete === true && $edit === false): ?>
     <div class="profile__container">
         <section class="profile__success-message-container"> 
             <h1 class="profile__title"><?php print __('Profile Created'); ?></h1>
@@ -12,7 +12,11 @@
             </div>
         </section>
     </div>
-    <?php else: ?>
+<?php elseif($complete === true && $edit === true): ?>
+    <script type="text/javascript">
+        window.location = "/members/<?php print $user->user_nicename;?>";
+    </script>
+<?php else: ?>
     <div class="profile__hero">
         <div class="profile__hero-container">
             <div class="profile__hero-content">
@@ -31,7 +35,6 @@
             </div>
         </div>
     </div>
-    
     <form class="profile__form" id="complete-profile-form" method="post" novalidate>
         <?php print wp_nonce_field('protect_content', 'my_nonce_field'); ?>
         <section class="profile__form-container profile__form-container--first">
@@ -216,7 +219,7 @@
                             <path d="M8.12499 9L12.005 12.88L15.885 9C16.275 8.61 16.905 8.61 17.295 9C17.685 9.39 17.685 10.02 17.295 10.41L12.705 15C12.315 15.39 11.685 15.39 11.295 15L6.70499 10.41C6.51774 10.2232 6.41251 9.96952 6.41251 9.705C6.41251 9.44048 6.51774 9.18683 6.70499 9C7.09499 8.62 7.73499 8.61 8.12499 9Z" fill="black" fill-opacity="0.54"/>
                         </g>
                     </svg>
-                    <select id="country" name="country" class="profile__select<?php if($form && !isset($form['country']) || (isset($form['country']) && empty(trim($form['country'])))): ?> profile__select--error<?php endif; ?>" required>
+                    <select id="country" name="country" class="profile__select<?php if($form && !isset($form['country']) || (isset($form['country']) && empty(trim($form['country'])))): ?> profile__select--error<?php endif; ?>">
                         <?php foreach($countries AS $key    =>  $value): ?>
                         <option value="<?php print $key; ?>"<?php if($form && isset($form['country']) && $form['country'] == $key): ?> selected<?php else: ?><?php if(isset($meta['country'][0]) && $meta['country'][0] == $key): ?> selected<?php endif; ?><?php endif; ?>><?php print $value; ?></option>
                         <?php endforeach; ?>
@@ -227,7 +230,7 @@
                 </div>
                 <div class="profile__input-container">
                     <label class="profile__label" for="city"><?php print __("City (optional)"); ?></label>
-                    <input type="text" name="city" id="city" class="profile__input<?php if($form && !isset($form['city']) || (isset($form['city']) && empty(trim($form['city'])) )): ?> profile__input--error<?php endif; ?>" placeholder="<?php print __("City"); ?>" value="<?php print isset($form['city']) ? $form['city'] : $meta['city'][0]; ?>" required />
+                    <input type="text" name="city" id="city" class="profile__input<?php if($form && !isset($form['city']) || (isset($form['city']) && empty(trim($form['city'])) )): ?> profile__input--error<?php endif; ?>" placeholder="<?php print __("City"); ?>" value="<?php print isset($form['city']) ? $form['city'] : $meta['city'][0]; ?>" />
                     <div class="form__error-container<?php if($form && !isset($form['last_name']) || (isset($form['city']) && empty(trim($form['city'])) )): ?> form__error-container--visible<?php endif; ?>">
                         <div class="form__error"><?php print __("This field is required"); ?></div>
                     </div>

--- a/buddypress/members/single/home.php
+++ b/buddypress/members/single/home.php
@@ -478,6 +478,7 @@
             do_action('bp_before_edit_member_page');
 
             $complete = ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['complete']) && $_POST['complete'] === true) ? true :  false;
+            $edit = ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['edit']) && $_POST['edit'] === true) ? true :  false;
             $updated_username = isset($form['username']) ? $form['username'] : false;
 
             include("{$template_dir}/buddypress/members/single/edit.php");

--- a/buddypress/members/single/profile.php
+++ b/buddypress/members/single/profile.php
@@ -71,7 +71,7 @@
             <div class="profile__name-container">
                 <h3 class="profile__user-title"><?php print $user->user_nicename; ?></h3>
                 <span class="profile__user-name">
-                    <?php if($visibility_settings['first_name_visibility'] || $logged_in): ?>
+                    <?php if($visibility_settings['first_name_visibility'] || $is_me): ?>
                     <?php print "{$community_fields['first_name']}"; ?>
                     <?php endif; ?>
                     <?php if($visibility_settings['last_name_visibility']): ?>
@@ -100,6 +100,7 @@
             <span class="profile__contact-title"><?php print __('Contact Information'); ?></span>
             <?php endif; ?>
             <?php if($visibility_settings['profile_location_visibility']): ?>
+            <?php if(isset($community_fields['city']) && strlen($community_fields['city']) > 0 || isset($community_fields['country']) && strlen($community_fields['country']) > 0): ?>
             <div class="profile__location-container">
                 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" class="profile__location-icon">
                     <circle cx="16" cy="16" r="16" fill="#CDCDD4"/>
@@ -117,20 +118,22 @@
                     <?php print __('Location'); ?>
                     <span class="profile__city-country">
                     <?php 
-                        if(isset($community_fields['city']))
+                        if(isset($community_fields['city']) && strlen($community_fields['city']) > 0)
                             print $community_fields['city'];
 
-                        if(isset($community_fields['city']) && isset($community_fields['country'])) {
+                        if(isset($community_fields['city']) && strlen($community_fields['city']) > 0 && isset($community_fields['country']) && strlen($community_fields['country']) > 0) {
                             print ", {$community_fields['country']}";
                         } else {
-                            if(isset($community_fields['country'])) {
+                            if(isset($community_fields['country']) && strlen($community_fields['country']) > 0) {
                                 print $community_fields['country'];
                             }
                         }
                     ?>
                     </span>
+                    
                 </div>
             </div>
+            <?php endif; ?>
             <?php endif; ?>
             <?php if($visibility_settings['email_visibility']): ?>
             <div class="profile__email-container">
@@ -143,7 +146,7 @@
                 <div class="profile__details">
                     <span class="profile__email">
                     <?php 
-                        if(isset($community_fields['email']))
+                        if(isset($community_fields['email']) && strlen($community_fields['email']) > 0)
                             print $community_fields['email'];
                     ?>
                     </span>
@@ -151,7 +154,7 @@
 
             </div>
             <?php endif; ?>
-            <?php if($visibility_settings['phone_visibility']): ?>
+            <?php if($visibility_settings['phone_visibility'] && isset($community_fields['phone']) && strlen($community_fields['phone']) > 0): ?>
             <div class="profile__phone-container">
                 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" class="profile__phone-icon">
                     <circle cx="16" cy="16" r="16" fill="#CDCDD4"/>

--- a/functions.php
+++ b/functions.php
@@ -736,6 +736,7 @@ function mozilla_update_member() {
     if($_SERVER['REQUEST_METHOD'] === 'POST') {
         if(is_user_logged_in()) {
             $user = wp_get_current_user()->data;
+            $edit = false;
 
             // Get current meta to compare to
             $meta = get_user_meta($user->ID);
@@ -787,9 +788,8 @@ function mozilla_update_member() {
             // Add additional required fields after initial setup
             if(isset($meta['agree'][0]) && $meta['agree'][0] == 'I Agree') {
                 unset($required[8]);
-                $required[] = 'city';
-                $required[] = 'country';
                 $required[] = 'profile_location_visibility';
+                $_POST['edit'] = true;
             }
 
             $error = false;
@@ -880,6 +880,7 @@ function mozilla_update_member() {
                 }    
 
                 update_user_meta($user->ID, 'community-meta-fields', $additional_meta);
+
             }
         }
     }


### PR DESCRIPTION
If not editing the profile for the first time redirect the user to their public profile after editing.  If it is their first time logging in and editing their profile before agreeing to the community guidelines after editing we redirect them to the thanks for creating your profile page instead of their profile.  

You should test both of these conditions with editing an existing user and signing in with a new user.

