### PR TITLE
Added text decoration none

### DIFF
--- a/scss/_profile.scss
+++ b/scss/_profile.scss
@@ -629,6 +629,7 @@
     &__button {
         @extend .cta;
         border-radius: 28px;
+        text-decoration: none;
 
         &:first-of-type {
             margin-bottom: 24px;
@@ -648,6 +649,7 @@
             background-color: transparent;
             border: 1px solid $color-blue-50;
             color: $color-blue-50;
+            text-decoration: none;
         }
     }
 


### PR DESCRIPTION
For some reason the CTAs on the profile editing confirmation page have underlines on wpengine but not locally, Im guessing there is some style that is overriding it that is specific to wpengine.  Added styles directly to these classes to see if it rectifies the problem, I don't have any underlines on the CTAs on my local machine so maybe we just push this through since we can only test on wpengine

