### PR TITLE
Feature/moz 65 gdpr popup

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,4 +1,43 @@
         <footer class="footer">
+            <?php
+
+                $args = Array(
+                    'category_name'  =>  'GDRP',
+                );
+
+                $gdrp_post = get_posts($args);
+            ?>
+
+            <?php if(sizeof($gdrp_post) > 0): ?>
+            <?php
+
+            ?>
+            <div class="gdrp">
+                <div class="gdrp__container">
+                    <a href="#" class="gdrp__close">
+                        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M17 1L1 17" stroke="#F9F9FA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            <path d="M1 1L17 17" stroke="#F9F9FA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                    </a>
+
+                    <h2 class="gdrp__title"><?php print $gdrp_post[0]->post_title; ?></h2>
+                    <?php 
+                        $content = apply_filters( 'the_content', $gdrp_post[0]->post_content);
+                        $content = str_replace( ']]>', ']]&gt;', $content );
+                        print $content;
+                    ?>
+                    <div class="gdrp__cta-container">
+                        <a href="#" class="gdrp__cta"><?php print __("Accept"); ?></a>
+                        <a href="#" class="gdrp__link">
+                            <?php print __("More Information"); ?><svg width="8" height="10" viewBox="0 0 8 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M2.33325 8.66683L5.99992 5.00016L2.33325 1.3335" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <?php endif; ?>
             <div class="footer__container">
                 <div class="footer__logo-container">
                     <img src="<?php print get_stylesheet_directory_uri(); ?>/images/footer-logo.png"  class="footer__logo" alt="Mozilla Logo" />

--- a/footer.php
+++ b/footer.php
@@ -22,10 +22,8 @@
                     </a>
 
                     <h2 class="gdrp__title"><?php print $gdrp_post[0]->post_title; ?></h2>
-                    <?php 
-                        $content = apply_filters( 'the_content', $gdrp_post[0]->post_content);
-                        $content = str_replace( ']]>', ']]&gt;', $content );
-                        print $content;
+                    <?php
+                        print  $gdrp_post[0]->post_content;
                     ?>
                     <div class="gdrp__cta-container">
                         <a href="#" class="gdrp__cta"><?php print __("Accept"); ?></a>

--- a/footer.php
+++ b/footer.php
@@ -1,17 +1,17 @@
         <footer class="footer">
             <?php
-
-                $args = Array(
-                    'category_name'  =>  'GDRP',
-                );
-
-                $gdrp_post = get_posts($args);
+                if(!isset($_COOKIE['gdrp'])) {
+                    $args = Array(
+                        'category_name'  =>  'GDRP',
+                    );
+    
+                    $gdrp_post = get_posts($args);
+                } else {
+                    $gdrp_post = Array();
+                }
             ?>
 
             <?php if(sizeof($gdrp_post) > 0): ?>
-            <?php
-
-            ?>
             <div class="gdrp">
                 <div class="gdrp__container">
                     <a href="#" class="gdrp__close">
@@ -29,11 +29,6 @@
                     ?>
                     <div class="gdrp__cta-container">
                         <a href="#" class="gdrp__cta"><?php print __("Accept"); ?></a>
-                        <a href="#" class="gdrp__link">
-                            <?php print __("More Information"); ?><svg width="8" height="10" viewBox="0 0 8 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M2.33325 8.66683L5.99992 5.00016L2.33325 1.3335" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                            </svg>
-                        </a>
                     </div>
                 </div>
             </div>

--- a/functions.php
+++ b/functions.php
@@ -387,6 +387,7 @@ function mozilla_init_scripts() {
     wp_enqueue_script('nav', get_stylesheet_directory_uri()."/js/nav.js", array('jquery'));
     wp_enqueue_script('profile', get_stylesheet_directory_uri()."/js/profile.js", array('jquery'));
     wp_enqueue_script('lightbox', get_stylesheet_directory_uri()."/js/lightbox.js", array('jquery'));
+    wp_enqueue_script('gdrp', get_stylesheet_directory_uri()."/js/gdrp.js", array('jquery'));
     
 
 }

--- a/js/gdrp.js
+++ b/js/gdrp.js
@@ -1,0 +1,18 @@
+jQuery(function(){
+
+
+    jQuery('.gdrp__cta, .gdrp__close').click(function(e){
+        e.preventDefault();
+        var domain = window.location.hostname;
+        domain = domain.substring(domain.lastIndexOf(".", domain.lastIndexOf(".") - 1) + 1)
+        document.cookie = "gdrp=true;path=/;domain=" + domain;
+
+        jQuery('.gdrp').addClass('gdrp--hide');        
+
+
+        return false;
+    });
+
+
+
+});

--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -3,6 +3,7 @@
     background-color: $color-black;
     min-height: 387px;
     margin-top: 58px;
+    position: relative;
 
 
     @include tablet-and-up {

--- a/scss/_gdrp.scss
+++ b/scss/_gdrp.scss
@@ -1,0 +1,120 @@
+.gdrp {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    background-color: $color-black;
+    min-height: 387px;
+
+
+    @include tablet-and-up {
+
+    }
+
+    @include desktop-and-up {
+        min-height: none;
+    }
+    
+    left: 0;
+    border-top: 1px solid $color-gray-secondary;
+
+    
+    &__container {
+        margin: 0 auto;
+        position: relative;
+        padding: 48px 24px;
+
+        p {
+            color: $color-white;
+            margin: 0;
+            padding: 0;
+            margin-bottom: 8px;
+            font-size: remCalc(16);
+            line-height: 28px;
+        }
+
+        a {
+            color: $color-white;
+
+        }
+
+        @include tablet-and-up {
+            padding: 48px 64px;
+        }
+        
+        @include desktop-and-up {
+            max-width: 1440px;
+            padding: 64px 106px 83px 106px;
+        }
+    }
+
+    &__title {
+        font-family: 'Zilla Slab';
+        color: $color-white;
+        font-size: remCalc(24);
+        line-height: 29px;
+
+        @include desktop-and-up {
+            font-size: remCalc(32);
+            line-height: 40px;
+            
+        }
+    }
+
+    &__cta-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin: 0;
+        padding: 0;
+        margin-top: 16px;
+
+        @include tablet-and-up {
+            flex-direction: row;
+            justify-content: flex-start;
+        }
+    }
+
+    &__cta {
+        background-color: $color-blue-50;
+        text-decoration: none;
+        color: $color-white;
+        font-size: remCalc(14);
+        line-height: 22px;
+        width: 100%;
+        border-radius: 28px;
+        padding: 10px 0;
+        text-align: center;
+        margin-bottom: 16px;
+
+        @include tablet-and-up {
+            font-size: remCalc(16);
+            padding: 15px 0;
+            line-height: 18px;
+            margin-bottom: 0;
+            max-width: 146px;
+            margin-right: 16px;
+        }
+    }
+
+    &__link {
+        text-decoration: none;
+        svg {
+            margin-left: 0;
+        }
+    }
+
+    &__close {
+        position: absolute;
+        top: 54px;
+        right: 24px;
+
+        @include tablet-and-up {
+
+        }
+
+        @include desktop-and-up {
+            top: 76px;
+            right: 106px;
+        }
+    }
+}

--- a/scss/_gdrp.scss
+++ b/scss/_gdrp.scss
@@ -1,5 +1,6 @@
 .gdrp {
     position: fixed;
+    z-index: 10000;
     bottom: 0;
     width: 100%;
     background-color: $color-black;

--- a/scss/_gdrp.scss
+++ b/scss/_gdrp.scss
@@ -5,19 +5,13 @@
     background-color: $color-black;
     min-height: 387px;
 
-
-    @include tablet-and-up {
-
-    }
-
     @include desktop-and-up {
-        min-height: none;
+        min-height: 0;
     }
     
     left: 0;
     border-top: 1px solid $color-gray-secondary;
 
-    
     &__container {
         margin: 0 auto;
         position: relative;
@@ -34,16 +28,15 @@
 
         a {
             color: $color-white;
-
         }
 
         @include tablet-and-up {
-            padding: 48px 64px;
+            padding: 32px 64px;
         }
         
         @include desktop-and-up {
             max-width: 1440px;
-            padding: 64px 106px 83px 106px;
+            padding: 32px 106px 32px 106px;
         }
     }
 
@@ -52,11 +45,13 @@
         color: $color-white;
         font-size: remCalc(24);
         line-height: 29px;
+        margin: 0;
+        padding: 0;
+        margin-bottom: 16px;
 
         @include desktop-and-up {
             font-size: remCalc(32);
             line-height: 40px;
-            
         }
     }
 
@@ -109,12 +104,16 @@
         right: 24px;
 
         @include tablet-and-up {
-
+            top: 38px;
         }
 
         @include desktop-and-up {
-            top: 76px;
+            top: 44px;
             right: 106px;
         }
+    }
+
+    &--hide {
+        display: none;
     }
 }

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -18,6 +18,7 @@
 @import "footer";
 @import "events";
 @import "event-single";
+@import "gdrp";
 @import "groups";
 @import "group";
 @import "members";


### PR DESCRIPTION
Added the GDRP overlay

![Screen Shot 2019-11-20 at 1 31 23 PM](https://user-images.githubusercontent.com/2521244/69268422-18ad4100-0b9d-11ea-8ab1-f298bca422ac.png)

You will need to do a couple things to get this to work.

1. Create a new category under posts called "GDRP"
2. Create a new post called "Privacy Policy" with the following content 

> <p>We use cookies to improve your experience on our site and to show you personalized advertising.</p>
> 
> <p>To find out more, read our <a href="#">privacy policy </a>and <a href="#">cookie policy</a>.</p>
> 

3. Next assign this post with the GDRP category

![Screen Shot 2019-11-20 at 1 58 42 PM](https://user-images.githubusercontent.com/2521244/69268841-e0f2c900-0b9d-11ea-9367-0b1b52f6a066.png)

Refresh any page and the popup should appear now.  Clicking the accept or x should remove it.  If you want it to show up again just delete the GDRP cookie.

![Screen Shot 2019-11-20 at 1 59 56 PM](https://user-images.githubusercontent.com/2521244/69268957-0e3f7700-0b9e-11ea-9ae2-7fdd955e01ff.png)
