### PR TITLE
Fixed bug with member items not wrapping

### DIFF
--- a/scss/_group.scss
+++ b/scss/_group.scss
@@ -559,9 +559,11 @@
         display: flex;
         flex-direction: column;
 
+
         @include tablet-and-up {
             justify-content: space-between;
             flex-direction: row;
+            flex-wrap: wrap;
         }
     }
 


### PR DESCRIPTION
This PR fixes this bug

![Screen Shot 2019-11-21 at 1 00 49 PM](https://user-images.githubusercontent.com/2521244/69363856-3f33b080-0c5f-11ea-8672-b34115205f5b.png)

with flex-wrap: wrap