### PR TITLE
Fixed event card top border radius

### DIFF
--- a/scss/_cards.scss
+++ b/scss/_cards.scss
@@ -17,6 +17,8 @@
     background-size: cover;
     background-position: center 50%;
     background-image: url("./images/event.jpg");
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
     img {
       max-width: 100%;
       display: block;


### PR DESCRIPTION
Top border radius cards weren't working on events page.  Now fixed added border-top-left/right-radius to event-card__image class