### PR TITLE
Added first name search

### DIFF
--- a/buddypress/members/index-directory.php
+++ b/buddypress/members/index-directory.php
@@ -2,11 +2,7 @@
     get_header(); 
     $logged_in = mozilla_is_logged_in();
 
-    $c = count_users();
-
     $members_per_page = 20;
-    $total_pages = ceil($c['total_users'] / $members_per_page);
-
     $page = isset($_GET['page']) ? intval($_GET['page']) : 0;
 
     $offset = ($page - 1) * $members_per_page;
@@ -20,9 +16,14 @@
     if($search_user) {
         $args['search'] = "*{$search_user}*";
         $args['search_columns'] = Array('nicename');
+
+        if($logged_in) {
+            $args['search_columns'][] = 'first_name';
+        }
     }
 
     $members = get_users($args);
+    $total_pages = ceil(sizeof($members) / $members_per_page);
     $logged_in = mozilla_is_logged_in();
 
 ?>


### PR DESCRIPTION
So I've added first name search, last name search and any other field protected by visibility settings will be a much more complicated algorithm.  Because the only thing that is really protecting first name is being logged in we don't need to pull the entire list of members and can use the default wordpress mechanism to search first name.

Will have to rethink how to search subsequent fields and still be fast.