### PR TITLE
Feature/moz 286 let secondary admin leave

### DIFF
--- a/buddypress/groups/index-directory.php
+++ b/buddypress/groups/index-directory.php
@@ -181,7 +181,7 @@
                 <?php endif; ?>
                 <?php foreach($groups AS $group): ?>
                     <?php 
-                        $meta = $group->meta;
+                        $meta = isset($group->meta) && is_array($group->meta) ? $group->meta : Array();
                         $member_count = groups_get_total_member_count($group->id);
                         $group_name = $group->name;
 
@@ -189,13 +189,14 @@
                             $group_name = substr($group_name, 0, 45)."&#133;";
                         }
 
-                        if((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443) {
-                            $group_image_url = preg_replace("/^http:/i", "https:", $meta['group_image_url']);
-                        } else {
-                            $group_image_url = $meta['group_image_url'];
+                        if(is_array($meta) && isset($meta['group_image_url'])) {
+                            if((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443) {
+                                $group_image_url = preg_replace("/^http:/i", "https:", $meta['group_image_url']);
+                            } else {
+                                $group_image_url = $meta['group_image_url'];
+                            }
                         }
-                        
-
+                    
                     ?>
 
                     <a href="/groups/<?php print $group->slug; ?>" class="groups__card">
@@ -235,6 +236,7 @@
                                     <?php 
                                         $tag_counter = 0;
                                     ?>
+                                    <?php if(isset($meta['group_tags']) && is_array($meta['group_tags'])): ?>
                                     <?php foreach(array_unique($meta['group_tags']) AS $key =>  $value): ?>
                                         <span class="groups__tag"><?php print $value; ?></span>
                                         <?php $tag_counter++; ?>
@@ -243,6 +245,7 @@
                                         <?php break; ?>
                                         <?php endif; ?>
                                     <?php endforeach; ?>
+                                    <?php endif; ?>
                                 </div>
                             </div>
                         </div>

--- a/buddypress/groups/index-directory.php
+++ b/buddypress/groups/index-directory.php
@@ -196,7 +196,6 @@
                                 $group_image_url = $meta['group_image_url'];
                             }
                         }
-                    
                     ?>
 
                     <a href="/groups/<?php print $group->slug; ?>" class="groups__card">

--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -35,8 +35,7 @@
     );
     
     $members = groups_get_group_members($args); 
-    $is_admin = groups_is_user_admin($user->ID, $group->id);
-
+    $is_admin = groups_is_user_admin($user->ID, $group->id) && $user->ID === $group->creator_id;
 
     switch($group->status) {
         case 'public':

--- a/functions.php
+++ b/functions.php
@@ -716,14 +716,14 @@ function mozilla_leave_group() {
         if($user->ID) {
             if(isset($_POST['group']) && $_POST['group']) {
                 $group = intval(trim($_POST['group']));
-                if(!groups_is_user_admin($user->ID, $group)) {
-                    
+                $group_object = groups_get_group(Array('group_id' => $group));
+                if($group_object->creator_id !== $user->ID) {
                     $left = groups_leave_group($group, $user->ID);
 
                     if($left) {
                         print json_encode(Array('status'   =>  'success', 'msg'  =>  'Left Group'));
                     } else {
-                        print json_encode(Array('status'   =>  'error', 'msg'   =>  'Could not leaev group'));
+                        print json_encode(Array('status'   =>  'error', 'msg'   =>  'Could not leave group'));
                     }
                 } else {
                     print json_encode(Array('status'   =>  'error', 'msg'   =>  'Admin cannot leave a group'));

--- a/functions.php
+++ b/functions.php
@@ -505,8 +505,12 @@ function mozilla_create_group() {
                                 }
 
                                 if(isset($_POST['group_admin_id']) && $_POST['group_admin_id']) {
-                                    groups_join_group($group_id, intval($_POST['group_admin_id']));
-                                    groups_promote_member(intval($_POST['group_admin_id']), $group_id, 'admin');
+                                    $group_admin_user_id = intval($_POST['group_admin_id']);
+
+                                    groups_join_group($group_id, $group_admin_user_id);
+                                    $member = new BP_Groups_Member($group_admin_user_id, $group_id); 
+                                    do_action('groups_promote_member', $group_id, $group_admin_user_id, 'admin'); 
+                                    $member->promote('admin'); 
                                 }
 
                                 // Required information but needs to be stored in meta data because buddypress does not support these fields

--- a/functions.php
+++ b/functions.php
@@ -504,7 +504,10 @@ function mozilla_create_group() {
                                     }
                                 }
 
-                                if(isset($_POST['group_admin_id']) && $_POST['group_admin_id']) {
+                                $group = groups_get_group(Array('group_id' => $group_id ));
+                                $user = wp_get_current_user();
+
+                                if(isset($_POST['group_admin_id']) && $_POST['group_admin_id'] && $group->creator_id == $user->ID) {
                                     $group_admin_user_id = intval($_POST['group_admin_id']);
 
                                     groups_join_group($group_id, $group_admin_user_id);
@@ -529,7 +532,7 @@ function mozilla_create_group() {
                                     unset($_SESSION['form']);
                                     $_POST = Array();
                                     $_POST['step'] = 3;
-                                    $group = groups_get_group(Array('group_id' => $group_id ));
+                                    
                                     $_POST['group_slug'] = $group->slug;
                                 } else {
                                     groups_delete_group($group_id);

--- a/js/groups.js
+++ b/js/groups.js
@@ -124,7 +124,7 @@ jQuery(function(){
         };
 
         var url =  '/wp-admin/admin-ajax.php?action=join_group';
-        console.log("Join");
+
         jQuery.ajax({
             url: url,
             data: post,
@@ -140,12 +140,14 @@ jQuery(function(){
                     jQuery('.group__member-count').text(memberCount);
                     $this.addClass('group__leave-cta');
                     $this.removeClass('group__join-cta');
-
+                    location.reload();
                 } else {
                     if(response.status === 'error' && response.msg === 'Not Logged In') {
                         window.location = '/login';
                     }
                 }
+
+
             }
         });
         return false;
@@ -180,7 +182,7 @@ jQuery(function(){
                     $this.addClass('group__join-cta');
                     $this.removeClass('group__leave-cta');
                     
-
+                    location.reload();
                 } else {
                     if(response.status === 'error' && response.msg === 'Not Logged In') {
                         window.location = '/login';
@@ -245,8 +247,7 @@ jQuery(function(){
     source: function(term, suggest) {
         jQuery.getJSON('/wp-admin/admin-ajax.php?action=get_users', { q: term }, function(data){
             var users = [];
-            console.log(data);
-            
+
             for(var x = 0; x < data.length; x++) {
                 users.push(data[x].data.ID+ ":" + data[x].data.user_nicename );
             }

--- a/js/groups.js
+++ b/js/groups.js
@@ -245,9 +245,10 @@ jQuery(function(){
     source: function(term, suggest) {
         jQuery.getJSON('/wp-admin/admin-ajax.php?action=get_users', { q: term }, function(data){
             var users = [];
-
+            console.log(data);
+            
             for(var x = 0; x < data.length; x++) {
-                users.push(data[x].data.ID+ ":" + data[x].data.user_login );
+                users.push(data[x].data.ID+ ":" + data[x].data.user_nicename );
             }
             
             suggest(users);


### PR DESCRIPTION
Allows secondary admins to leave a group.  
- Also fixed issue with adding secondary admins when creating a group.