### PR TITLE
Changed topic URL to use ID instead of slug because of non latin titles

### DIFF
--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -524,7 +524,7 @@
                                     <?php foreach($topics AS $topic): ?>
                                         <tr>
                                             <td class="group__table-cell group__table-cell--topic">
-                                                <a href="<?php print $options['discourse_url']; ?>/t/<?php print $topic->slug; ?>" class="group__topic-link">
+                                                <a href="<?php print $options['discourse_url']; ?>/t/topic/<?php print $topic->id; ?>" class="group__topic-link">
                                                     <div class="group__topic-title"><?php print $topic->title; ?></div>
                                                     <div class="group__topic-date"><?php print date("F j, Y", strtotime($topic->created_at)); ?></div>
                                                 </a>


### PR DESCRIPTION
Updating topic links found in the individual group pages.  Before we were using the slug to create the discourse topic URL.  That was causing issues with topic titles that were non latin.  

I have updated the URL to use the topic id as per Leo to generate the URL.

![Screen Shot 2020-01-31 at 12 11 42 PM](https://user-images.githubusercontent.com/2521244/73559355-dd43b400-4422-11ea-86f3-61c2f3ae367a.png)
