### PR TITLE
Fix/moz 324 report links events groups

### DIFF
--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -685,6 +685,19 @@
                     </div>
                     <?php endif; ?>
                 </section>
+                <?php $options = wp_load_alloptions(); ?>
+                <?php if(isset($options['report_email'])): ?>
+                <div class="group__report-container">
+                    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s - %s', __('Reporting Group', 'community-portal'), $group->name, "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}" ); ?>&body=<?php print __('Please provide a reason you are reporting this group', 'community-portal'); ?>" class="group__report-group-link">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            <path d="M12 8V12" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            <circle cx="12" cy="16" r="0.5" fill="#CDCDD4" stroke="#0060DF"/>
+                        </svg>
+                        <?php print __("Report Group", 'community-portal'); ?>
+                    </a>
+                </div>
+                <?php endif; ?>
             </div>
         </div>
     </div>

--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -687,7 +687,7 @@
                 </section>
                 <?php if(isset($options['report_email'])): ?>
                 <div class="group__report-container">
-                    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Group', 'community-portal'), $group->name); ?>&body=<?php print __(sprintf('Please provide a reason you are reporting this group    %s', "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}"), 'community-portal'); ?>" class="group__report-group-link">
+                    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Group', 'community-portal'), $group->name); ?>&body=<?php print __(sprintf('Please provide a reason you are reporting this group    %s', "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}"), 'community-portal'); ?>" class="group__report-group-link">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             <path d="M12 8V12" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -687,7 +687,7 @@
                 </section>
                 <?php if(isset($options['report_email'])): ?>
                 <div class="group__report-container">
-                    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s - %s', __('Reporting Group', 'community-portal'), $group->name, "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}" ); ?>&body=<?php print __('Please provide a reason you are reporting this group', 'community-portal'); ?>" class="group__report-group-link">
+                    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Group', 'community-portal'), $group->name); ?>&body=<?php print __(sprintf('Please provide a reason you are reporting this group    %s', "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}"), 'community-portal'); ?>" class="group__report-group-link">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             <path d="M12 8V12" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -685,7 +685,6 @@
                     </div>
                     <?php endif; ?>
                 </section>
-                <?php $options = wp_load_alloptions(); ?>
                 <?php if(isset($options['report_email'])): ?>
                 <div class="group__report-container">
                     <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s - %s', __('Reporting Group', 'community-portal'), $group->name, "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}" ); ?>&body=<?php print __('Please provide a reason you are reporting this group', 'community-portal'); ?>" class="group__report-group-link">

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -171,6 +171,10 @@ function mozilla_theme_settings() {
             if(isset($_POST['mapbox'])) {
                 update_option('mapbox', sanitize_text_field($_POST['mapbox']));
             }   
+
+            if(isset($_POST['report_email'])) {
+                update_option('report_email', sanitize_text_field($_POST['report_email']));
+            }
         }
     }
 

--- a/plugins/events-manager/templates/event-single.php
+++ b/plugins/events-manager/templates/event-single.php
@@ -381,7 +381,7 @@
 </div>
 <?php if(isset($options['report_email'])): ?>
 <div class="events-single__report-container">
-    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s - %s', __('Reporting Event', 'community-portal'), $group->name, "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}" ); ?>&body=<?php print __('Please provide a reason you are reporting this event', 'community-portal'); ?>" class="events-single__report-group-link">
+    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Event', 'community-portal'), $group->name); ?>&body=<?php print sprintf('%s %s', __('Please provide a reason you are reporting this event', 'community-portal'), "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}"); ?>" class="events-single__report-group-link">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M12 8V12" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/plugins/events-manager/templates/event-single.php
+++ b/plugins/events-manager/templates/event-single.php
@@ -379,3 +379,16 @@
         <?php include(locate_template('templates/share-modal.php', false, false)); ?>
     </div>
 </div>
+<?php $options = wp_load_alloptions(); ?>
+<?php if(isset($options['report_email'])): ?>
+<div class="events-single__report-container">
+    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s - %s', __('Reporting Event', 'community-portal'), $group->name, "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}" ); ?>&body=<?php print __('Please provide a reason you are reporting this event', 'community-portal'); ?>" class="events-single__report-group-link">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M12 8V12" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <circle cx="12" cy="16" r="0.5" fill="#CDCDD4" stroke="#0060DF"/>
+        </svg>
+        <?php print __("Report Event", 'community-portal'); ?>
+    </a>                                           
+</div>
+<?php endif ?>

--- a/plugins/events-manager/templates/event-single.php
+++ b/plugins/events-manager/templates/event-single.php
@@ -379,7 +379,6 @@
         <?php include(locate_template('templates/share-modal.php', false, false)); ?>
     </div>
 </div>
-<?php $options = wp_load_alloptions(); ?>
 <?php if(isset($options['report_email'])): ?>
 <div class="events-single__report-container">
     <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s - %s', __('Reporting Event', 'community-portal'), $group->name, "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}" ); ?>&body=<?php print __('Please provide a reason you are reporting this event', 'community-portal'); ?>" class="events-single__report-group-link">

--- a/plugins/events-manager/templates/event-single.php
+++ b/plugins/events-manager/templates/event-single.php
@@ -381,7 +381,7 @@
 </div>
 <?php if(isset($options['report_email'])): ?>
 <div class="events-single__report-container">
-    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Event', 'community-portal'), $group->name); ?>&body=<?php print sprintf('%s %s', __('Please provide a reason you are reporting this event', 'community-portal'), "https://{$_SERVER[HTTP_HOST]}{$_SERVER[REQUEST_URI]}"); ?>" class="events-single__report-group-link">
+    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Event', 'community-portal'), $group->name); ?>&body=<?php print sprintf('%s %s', __('Please provide a reason you are reporting this event', 'community-portal'), "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}"); ?>" class="events-single__report-group-link">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M12 8V12" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/scss/_campaign.scss
+++ b/scss/_campaign.scss
@@ -565,6 +565,7 @@
         }
 
         ol, ul {
+            line-height: 24px;
             margin: 0;
             margin-bottom: 16px;
             padding: 0;

--- a/scss/_campaign.scss
+++ b/scss/_campaign.scss
@@ -181,6 +181,7 @@
         margin: auto;
         max-width: 808px;
         padding: 16px;
+        width: 100%;
 
         @include tablet-and-up {
             padding: 24px;
@@ -258,7 +259,7 @@
         border-radius: 28px;
         color: $color-blue-50;
         font-size: remCalc(14);
-        height: 48px;
+        height: auto;
         line-height: 22px;
         max-width: 200px;
         min-width: 160px;
@@ -703,6 +704,7 @@
         background-color: $color-white;
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;
+        height: 100%;
         padding: 16px 32px 24px;
     }
 
@@ -752,7 +754,7 @@
         font-size: remCalc(14);
         letter-spacing: 0.0025em;
         line-height: 20px;
-        margin-bottom: 24px;
+        margin-bottom: 8px;
     }
 
     &__video-container {
@@ -794,10 +796,17 @@
     }
 
     &__imagery-image {
+        background-size: contain;
+        background-position: center center;
+        background-repeat: no-repeat;
         border-radius: 4px;
-        height: auto;
+        height: 342px;
         margin-bottom: 8px;
         width: 100%;
+
+        @include tablet-and-up {
+            background-size: cover;
+        }
     }
 
     &__imagery-caption {
@@ -813,5 +822,21 @@
         line-height: 18px;
         padding: 15px 35px;
         text-align: center;
+    }
+
+    &__campaign-events {
+        align-items: center;
+        color: $color-gray-secondary;
+        display: flex;
+        flex-direction: row;
+        font-size: remCalc(14);
+        letter-spacing: 0.0025em;
+        line-height: 20px;
+        margin-bottom: 24px;
+        margin-top: 8px;
+
+        svg {
+            margin-right: 8px;
+        }
     }
 }

--- a/scss/_event-single.scss
+++ b/scss/_event-single.scss
@@ -505,4 +505,31 @@
             }
         }
     }
+
+    &__report-container {
+        align-items: center;
+        border-bottom: 1px solid $color-gray-40;
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        margin: 0;
+        margin-top: 32px;
+        padding: 0;
+        padding-bottom: 32px;
+        width: 100%
+    }
+
+    &__report-group-link {
+        align-items: center;
+        color: $color-blue-50;
+        display: flex;
+        flex-direction: row;
+        font-size: remCalc(16);
+        line-height: 24px;
+        text-decoration: none;
+
+        svg {
+            margin-right: 8px;
+        }
+    }
 }

--- a/scss/_group.scss
+++ b/scss/_group.scss
@@ -798,4 +798,31 @@
             margin-left: 8px;
         }
     }
+
+    &__report-container {
+        align-items: center;
+        border-bottom: 1px solid $color-gray-40;
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        margin: 0;
+        margin-top: 32px;
+        padding: 0;
+        padding-bottom: 32px;
+        width: 100%
+    }
+
+    &__report-group-link {
+        align-items: center;
+        color: $color-blue-50;
+        display: flex;
+        flex-direction: row;
+        font-size: remCalc(16);
+        line-height: 24px;
+        text-decoration: none;
+
+        svg {
+            margin-right: 8px;
+        }
+    }
 }

--- a/templates/blocks/imagery_block.php
+++ b/templates/blocks/imagery_block.php
@@ -8,7 +8,7 @@
             <div class="campaign__imagery-images-container">
             <?php foreach($block['images'] AS $image): ?>
             <div class="campaign__imagery-image-container">
-                <img src="<?php print $image['image']['url']; ?>" class="campaign__imagery-image" />
+                <div style="background-image: url('<?php print $image['image']['url']; ?>'); background-color: <?php if(isset($image['background_color']) && strlen($image['background_color']) > 0): ?><?php print $image['background_color']; ?><?php else: ?> #ffffff<?php endif; ?>;" class="campaign__imagery-image"></div>
                 <div class="campaign__imagery-caption"><?php print $image['caption']; ?></div>
             </div>
             <?php endforeach; ?>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -5,6 +5,14 @@
         <tbody>
             <tr>
                 <th scope="row">
+                    <label for="report-email">Report Group / Event Email</label>
+                </th>
+                <td>
+                    <input type="text" id="report-email" name="report_email" class="regular-text" value="<?php print isset($options['report_email']) ? $options['report_email'] : ''; ?>" />
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
                     <label for="github-link">Github Link</label>
                 </th>
                 <td>


### PR DESCRIPTION
Adds the report links back into the group and event single pages.   You will need to go into the Mozilla theme settings and set reporting email.

![Screen Shot 2020-02-05 at 10 42 06 AM](https://user-images.githubusercontent.com/2521244/73856934-32f1d500-4804-11ea-9fc7-6c26872c589e.png)

