### PR TITLE
Added mailchimp API field to theme settings

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -176,6 +176,10 @@ function mozilla_theme_settings() {
             if(isset($_POST['report_email'])) {
                 update_option('report_email', sanitize_text_field($_POST['report_email']));
             }
+
+            if(isset($_POST['mailchimp'])) {
+                update_option('mailchimp', sanitize_text_field($_POST['mailchimp']));
+            }
         }
     }
 

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -29,6 +29,14 @@
             </tr>
             <tr>
                 <th scope="row">
+                    <label for="mailchimp">Mailchimp API Key</label>
+                </th>
+                <td>
+                    <input type="text" id="mailchimp" name="mailchimp" class="regular-text" value="<?php print $options['mailchimp']; ?>" />
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
                     <label for="google-analytics-id">Google Analytics ID</label>
                 </th>
                 <td>


### PR DESCRIPTION
Adds mailchimp API setting field to the Mozilla theme settings.

/wp-admin/admin.php?page=theme-panel