### PR TITLE
Quick fix

### DIFF
--- a/buddypress/groups/index-directory.php
+++ b/buddypress/groups/index-directory.php
@@ -17,7 +17,6 @@
 
 	$q = (isset($_GET['q']) && strlen($_GET['q']) > 0) ? sanitize_text_field(trim($_GET['q'])) : false;
 	if (isset($q)) {
-
 		if (
 			strpos($q, '"') !== false || 
 			strpos($q, "'") !== false || 
@@ -27,7 +26,9 @@
 			$q = preg_replace('/^\"|\"$|^\'|\'$/', "", $q);
 			$original_query = $q;
 			$q = addslashes($q);
-		}
+		} else {
+      $original_query = $q;
+    }
 
 		$args['search_columns'] = Array('name');
         $args['search_terms'] = $q;

--- a/plugins/events-manager/templates/events-list.php
+++ b/plugins/events-manager/templates/events-list.php
@@ -1,7 +1,6 @@
 <?php
     $page = isset($_REQUEST['pno']) ? intval($_REQUEST['pno']) : 1;
 	$args = apply_filters('em_content_events_args', $args);
-	var_dump(strpos($args['search'], "'"));
 	if (
 		isset($args['search']) && 
 		(strpos($args['search'], '"') !== false || 
@@ -11,6 +10,8 @@
 		$args['search'] = preg_replace('/^\"|\"$|^\'|\'$/', "", $args['search']);
 		$original_search = $args['search'];
 		$args['search'] = addslashes($args['search']);
+	} else {
+		$original_search = $args['search'];
 	}
     $view = get_query_var( 'view', $default = '');
     $country = urldecode(get_query_var('country', $default = 'all'));


### PR DESCRIPTION
Realized that I had neglected to add catch so that "Results for" text still showed up if the search term did not include an apostrophe or quotation marks.