### PR TITLE
Bug/moz 350 event single tags

### DIFF
--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -262,7 +262,6 @@
                                                 $month = substr($event->start_date, 5, 2);
                                                 $date = substr($event->start_date, 8, 2);
                                                 $year = substr($event->start_date, 0, 4);
-                                             
                                             ?>
                                             <p class="event-card__image__date"><span><?php echo substr($months[intval($month)],0,3) ?> </span><span><?php echo $date; ?></span></p>
                                         </div>
@@ -299,28 +298,15 @@
                                         <ul class="events__tags">
                                             <?php
                                             if (is_array($categories->terms)): 
-                                                if (count($categories->terms) <= 2): 
-                                                foreach($categories->terms as $category) {
+												if (count($categories->terms) <= 2): 
+													foreach($categories->terms as $category) {
                                             ?>
-                                                <li class="tag"><?php echo $category->name; ?></li>
-                                            <?php
-                                            }
-                                            elseif (count($categories->terms) > 0):
-                                                $i = 0;
-                                                foreach ($categories->terms as $category) {
-                                                ?>
-                                                <li class="tag"><?php echo $category->name; ?></li>
-                                                <?php
-                                                $i = $i + 1;
-                                                if ($i === 2) {
-                                                    break;
-                                                }
-                                                }
-                                                ?>
-                                                <li class="tag"><?php echo '+'; echo count($categories->terms) - 2; echo __(' more tag(s)', "community-portal"); ?></li>        
-                                                <?php
-                                            endif;
-                                            endif;
+													<li class="tag"><?php echo $category->name; ?></li>
+												<?php
+													break;
+												}
+												endif;
+											endif;
                                             ?>
                                         </ul>
                                     </a>
@@ -616,7 +602,7 @@
                                                 <path d="M8 9.66602C9.10457 9.66602 10 8.77059 10 7.66602C10 6.56145 9.10457 5.66602 8 5.66602C6.89543 5.66602 6 6.56145 6 7.66602C6 8.77059 6.89543 9.66602 8 9.66602Z" stroke="#737373" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                                             </svg>
                                             <?php if($location->location_country === 'OE'): ?>
-                                              <?php print __("Online Event", "community-portal"); ?>
+											<?php print __("Online Event", "community-portal"); ?>
                                             <?php elseif($location->location_town && $location->location_country): ?>
                                                 <?php print "{$location->location_town}, {$countries[$location->location_country]}"; ?>
                                             <?php elseif($location->location_town && !$location->location_country): ?>

--- a/plugins/events-manager/forms/event/categories-public.php
+++ b/plugins/events-manager/forms/event/categories-public.php
@@ -1,34 +1,33 @@
 <?php
-  global $EM_Event;
-  $categories = EM_Categories::get(array('orderby'=>'name','hide_empty'=>0));
+	global $EM_Event;
+	$categories = EM_Categories::get(array('orderby'=>'name','hide_empty'=>0));
 ?>
-<?php if( count($categories) > 0 ): 
-  ?>
-  <div class="event-categories event-creator__container">
-    <!-- START Categories -->
-    <fieldset class="event-creator__fieldset" id="event_categories[]">
-      <legend class="event-creator__label" for="event_categories[]"><?php print __( 'Select tag(s) for your event', 'commuity-portal'); ?></legend>
-        <?php
-          $selected = $EM_Event->get_categories()->get_ids();
-          foreach($categories as $category) {
-          ?>
-          <input 
-            name="event_categories[]" 
-            class="event-creator__checkbox" 
-            id="<?php echo esc_attr($category->id) ?>"
-            type="checkbox"  
-            value="<?php echo esc_attr($category->id) ?>"
-            <?php if (in_array($category->id, $selected)) {
-              echo esc_attr('checked'); 
-            } 
-            ?>
-          />
-          <label class="event-creator__tag" for="<?php echo esc_attr($category->id)?>"><?php echo __($category->name) ?></label>
-          <?php
-          }
-        ?>
+<?php if( count($categories) > 0 ): ?>
+	<div class="event-categories event-creator__container">
+	<!-- START Categories -->
+		<fieldset class="event-creator__fieldset" id="event_categories[]">
+			<legend class="event-creator__label" for="event_categories[]"><?php print __( 'Select tag(s) for your event', 'commuity-portal'); ?></legend>
+			<?php
+				$selected = $EM_Event->get_categories()->get_ids();
+				foreach($categories as $category) {
+			?>
+				<input 
+					name="event_categories[]" 
+					class="event-creator__checkbox" 
+					id="<?php echo esc_attr($category->id) ?>"
+					type="radio"  
+					value="<?php echo esc_attr($category->id) ?>"
+					<?php if (is_array($selected) && intval($category->id) === intval($selected[0])) {
+						echo esc_attr('checked'); 
+					} 
+					?>
+				/>
+				<label class="event-creator__tag" for="<?php echo esc_attr($category->id)?>"><?php echo __($category->name) ?></label>
+			<?php
+				}
+			?>
         <!-- <input type="hidden" name="event_categories[]" id="event_categories--all" value=""> -->
-      <!-- END Categories -->
-    </fieldset>
-  </div>
+		<!-- END Categories -->
+		</fieldset>
+	</div>
 <?php endif; ?>

--- a/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
+++ b/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
@@ -13,7 +13,8 @@
                     <p class="events-single__label"><?php print __('Tags', 'community-portal'); ?></p>
                     <ul class="events-single__tags">
                         <?php foreach($categories as $category): ?>
-                        <li class="tag"><a class="events-single__tag-link" href="/events/?tag=<?php print $category->name; ?>"><?php echo $category->name ?></a></li>
+							<li class="tag"><a class="events-single__tag-link" href="/events/?tag=<?php print $category->name; ?>"><?php echo $category->name ?></a></li>
+							<?php break;?>
                         <?php endforeach; ?>
                     </ul>
                 </div>

--- a/plugins/events-manager/templates/template-parts/single-event-card.php
+++ b/plugins/events-manager/templates/template-parts/single-event-card.php
@@ -39,7 +39,7 @@
             ?>
 
             <?php if ($img_url && $img_url !== ''): ?>
-             style="background-image: url(<?php echo $img_url ?>)"
+				style="background-image: url(<?php echo $img_url ?>)"
             <?php endif; ?>
             >
                 <?php 
@@ -111,25 +111,10 @@
             </div>
             <ul class="events__tags">
             <?php if ($categories !== false && is_array($categories->terms)): ?>
-            <?php if ($categories !== false && count($categories->terms) <= 2): ?>
-            <?php foreach($categories->terms as $category): ?>
-                <li class="tag"><?php echo __($category->name); ?></li>
-            <?php endforeach; ?>
-            <?php elseif ($categories !== false && count($categories->terms) > 0): ?>
-            <?php             
-                $i = 0;
-            ?>
-            <?php foreach ($categories->terms as $category): ?>
-                <li class="tag"><?php echo $category->name; ?></li>
-                <?php
-                    $i = $i + 1;
-                    if ($i === 2) {
-                        break;
-                    }
-                ?>
-            <?php endforeach; ?>
-                <li class="tag"><?php echo __('+'); echo count($categories->terms) - 2; echo __(' more tag(s)'); ?></li>        
-            <?php endif; ?>
+				<?php foreach($categories->terms as $category): ?>
+					<li class="tag"><?php echo __($category->name); ?></li>
+					<?php break;?>
+				<?php endforeach; ?>
             <?php endif; ?>
             </ul>
         </a>

--- a/templates/blocks/events_block.php
+++ b/templates/blocks/events_block.php
@@ -106,25 +106,10 @@
                         <?php endif; ?>
                         <ul class="events__tags">
                         <?php if ($categories !== false && is_array($categories->terms)): ?>
-                        <?php if ($categories !== false && count($categories->terms) <= 2): ?>
-                        <?php foreach($categories->terms as $category): ?>
-                            <li class="tag"><?php echo __($category->name); ?></li>
-                        <?php endforeach; ?>
-                        <?php elseif ($categories !== false && count($categories->terms) > 0): ?>
-                        <?php             
-                            $i = 0;
-                        ?>
-                        <?php foreach ($categories->terms as $category): ?>
-                            <li class="tag"><?php echo $category->name; ?></li>
-                            <?php
-                                $i = $i + 1;
-                                if ($i === 2) {
-                                    break;
-                                }
-                            ?>
-                        <?php endforeach; ?>
-                            <li class="tag"><?php echo __('+'); echo count($categories->terms) - 2; echo __(' more tag(s)'); ?></li>        
-                        <?php endif; ?>
+							<?php foreach($categories->terms as $category): ?>
+								<li class="tag"><?php echo __($category->name); ?></li>
+								<?php break; ?>
+							<?php endforeach; ?>
                         <?php endif; ?>
                         </ul>
                     </div>


### PR DESCRIPTION
Changed event tags to radio buttons so users can only select one. 
Updated event cards to only display first tag if multiple are selected on:
- Events Page
- Single Event page (in related events)
- Single Campaign (events block)
- Single Group (events view)