### PR TITLE
Feature/moz 340 add email api

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -13,6 +13,7 @@ include("{$theme_directory}/countries.php");
 
 // Require
 require_once("{$theme_directory}/lib/api.php");
+require_once("{$theme_directory}/lib/campaigns.php");
 require_once("{$theme_directory}/lib/groups.php");
 require_once("{$theme_directory}/lib/members.php");
 require_once("{$theme_directory}/lib/events.php");

--- a/functions.php
+++ b/functions.php
@@ -45,6 +45,10 @@ add_action('wp_ajax_nopriv_validate_group', 'mozilla_validate_group_name');
 add_action('wp_ajax_validate_group', 'mozilla_validate_group_name');
 add_action('wp_ajax_check_user', 'mozilla_validate_username');
 add_action('wp_ajax_delete_user', 'mozilla_delete_user');
+add_action('wp_ajax_mailchimp_subscribe', 'mozilla_mailchimp_subscribe');
+add_action('wp_ajax_nopriv_mailchimp_subscribe', 'mozilla_mailchimp_subscribe');
+
+
 
 // Auth0 Actions
 add_action('auth0_user_login', 'mozilla_post_user_creation', 10, 6);

--- a/js/campaigns.js
+++ b/js/campaigns.js
@@ -1,0 +1,30 @@
+jQuery(function() {
+
+    jQuery(document).on('click', '.campaign__hero-cta', function(e) {
+        e.preventDefault();
+        var $this = jQuery(this);
+        var campaign = $this.data('campaign');
+
+        var post = {
+            'campaign': campaign
+        };
+
+        var url =  '/wp-admin/admin-ajax.php?action=mailchimp_subscribe';
+
+        jQuery.ajax({
+            url: url,
+            data: post,
+            method: 'POST',
+            success: function(response) {
+                response = jQuery.parseJSON(response);
+                if(response.status == 'success') {
+                   
+                } else {
+                    
+                }
+            }
+        });
+        return false;
+    });
+
+});

--- a/js/campaigns.js
+++ b/js/campaigns.js
@@ -1,6 +1,6 @@
 jQuery(function() {
 
-    jQuery(document).on('click', '.campaign__hero-cta', function(e) {
+    jQuery(document).on('click', '.campaign__hero-cta--sub', function(e) {
         e.preventDefault();
         var $this = jQuery(this);
         var campaign = $this.data('campaign');

--- a/lib/api.php
+++ b/lib/api.php
@@ -292,7 +292,6 @@ function mozilla_add_email_to_list($id, $email) {
             
             $curl = curl_init();
             $api_url = "https://{$dc}.api.mailchimp.com/3.0/lists/{$id}/members";
-
             $auth_string = "user:{$apikey}";
             $auth = base64_encode($auth_string);
 
@@ -311,8 +310,9 @@ function mozilla_add_email_to_list($id, $email) {
             $result = curl_exec($curl);
             curl_close($curl);
 
-            $json_result = json_decode($result);
+            $result = json_decode($result);
         
+            return $json_result;
         }
     }
 }

--- a/lib/api.php
+++ b/lib/api.php
@@ -280,5 +280,41 @@ function mozilla_create_mailchimp_list($campaign) {
     return false;
 }
 
+function mozilla_add_email_to_list($id, $email) {
+
+    $options = wp_load_alloptions();
+
+    if(isset($options['mailchimp'])) {
+        $apikey = trim($options['mailchimp']);
+        $dc = substr($apikey, -3);
+
+        if($dc) {
+            
+            $curl = curl_init();
+            $api_url = "https://{$dc}.api.mailchimp.com/3.0/lists/{$id}/members";
+
+            $auth_string = "user:{$apikey}";
+            $auth = base64_encode($auth_string);
+
+            curl_setopt($curl, CURLOPT_URL, $api_url);
+            curl_setopt($curl, CURLOPT_HTTPHEADER, Array("Content-Type: application/json"));
+            curl_setopt($curl, CURLOPT_USERPWD, 'user:' . $apikey);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($curl, CURLOPT_POST, true);
+
+            $data = Array();
+            $data['email_address'] = $email;
+            $data['status'] = 'subscribed';
+
+            $json = json_encode($data);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
+            $result = curl_exec($curl);
+            curl_close($curl);
+
+            $json_result = json_decode($result);
+        
+        }
+    }
+}
 
 ?>

--- a/lib/api.php
+++ b/lib/api.php
@@ -311,8 +311,7 @@ function mozilla_add_email_to_list($id, $email) {
             curl_close($curl);
 
             $result = json_decode($result);
-        
-            return $json_result;
+            return $result;
         }
     }
 }

--- a/lib/campaigns.php
+++ b/lib/campaigns.php
@@ -1,0 +1,37 @@
+<?php
+
+function mozilla_mailchimp_subscribe() {
+
+    if($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if(isset($_POST['campaign']) && intval($_POST['campaign']) > 0) {
+            $user = wp_get_current_user();
+
+            // Only accepting logged in users at the moment
+            if($user->ID !== 0 && isset($user->data->user_email)) {
+                $campaign = intval($_POST['campaign']);    
+                $post = get_post($campaign);
+
+                if($post && $post->post_type === 'campaign') {
+                    $result = mozilla_add_email_to_list($campaign, $user->data->user_email);
+                    if(isset($result['id'])) {
+                        print json_encde(Array('status' =>  'OK'));
+                    }
+                } else {
+                    print json_encode(Array('status'    =>  'ERROR', 'message'  =>  'Invalid content'));
+                }
+            } else {
+                print json_encode(Array('status'    =>  'ERROR', 'message'  =>  'Invalid user'));
+            }
+        } else {
+            print json_encode(Array('status'    =>  'ERROR', 'message'  =>  'Invalid request'));
+        }
+    } else {
+        print json_encode(Array('status'    =>  'ERROR', 'message'  =>  'Invalid request'));
+    }
+
+    die();
+}
+
+
+
+?>

--- a/lib/campaigns.php
+++ b/lib/campaigns.php
@@ -3,22 +3,20 @@
 function mozilla_mailchimp_subscribe() {
 
     if($_SERVER['REQUEST_METHOD'] === 'POST') {
-        if(isset($_POST['campaign']) && intval($_POST['campaign']) > 0) {
+        if(isset($_POST['campaign']) && strlen(trim($_POST['campaign'])) > 0) {
             $user = wp_get_current_user();
 
             // Only accepting logged in users at the moment
             if($user->ID !== 0 && isset($user->data->user_email)) {
-                $campaign = intval($_POST['campaign']);    
-                $post = get_post($campaign);
+                $campaign = trim($_POST['campaign']);    
 
-                if($post && $post->post_type === 'campaign') {
-                    $result = mozilla_add_email_to_list($campaign, $user->data->user_email);
-                    if(isset($result['id'])) {
-                        print json_encde(Array('status' =>  'OK'));
-                    }
+                $result = mozilla_add_email_to_list($campaign, $user->data->user_email);
+                if(isset($result->id)) {
+                    print json_encode(Array('status' =>  'OK'));
                 } else {
-                    print json_encode(Array('status'    =>  'ERROR', 'message'  =>  'Invalid content'));
+                    print json_encode(Array('status'    =>  'ERROR', 'message'  =>  'User not added'));
                 }
+
             } else {
                 print json_encode(Array('status'    =>  'ERROR', 'message'  =>  'Invalid user'));
             }

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -99,6 +99,7 @@ function mozilla_init_scripts() {
     // Custom scripts
     wp_enqueue_script('groups', get_stylesheet_directory_uri()."/js/groups.js", array('jquery'));
     wp_enqueue_script('events', get_stylesheet_directory_uri()."/js/events.js", array('jquery'));
+    wp_enqueue_script('campaigns', get_stylesheet_directory_uri()."/js/campaigns.js", array('jquery'));
     wp_enqueue_script('activities', get_stylesheet_directory_uri()."/js/activities.js", array('jquery'));
     wp_enqueue_script('cleavejs', get_stylesheet_directory_uri()."/js/vendor/cleave.min.js", array());
     wp_enqueue_script('nav', get_stylesheet_directory_uri()."/js/nav.js", array('jquery'));

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -34,8 +34,8 @@
                             - <?php print $campaign_end_date; ?>
                             <?php endif; ?>
                         </div>
-                        <?php if($campaign_hero_cta && $logged_in): ?>
-                        <a href="<?php print ($campaign_hero_cta_link) ? $campaign_hero_cta_link : '#'; ?>" class="campaign__hero-cta"<?php if(isset($mailchimp->id)): ?> data-campaign="<?php print $mailchimp->id; ?>"<?php endif; ?>><?php print $campaign_hero_cta; ?></a>
+                        <?php if($campaign_hero_cta && $logged_in && isset($mailchimp->id)): ?>
+<a href="<?php print ($campaign_hero_cta_link) ? $campaign_hero_cta_link : '#'; ?>" class="campaign__hero-cta<?php if(isset($mailchimp->id)): ?> campaign__hero-cta--sub<?php endif; ?>"<?php if(isset($mailchimp->id)): ?> data-campaign="<?php print $mailchimp->id; ?>"<?php endif; ?>><?php print $campaign_hero_cta; ?></a>
                         <?php endif; ?>
                     </div>
                 </div>

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -15,6 +15,7 @@
 
     $tags = get_the_terms($post, 'post_tag');
 
+    $mailchimp = get_post_meta($post->ID, 'mailchimp-list-id', true);
 ?>
     <div class="content">
         <div class="campaign">

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -16,6 +16,8 @@
     $tags = get_the_terms($post, 'post_tag');
 
     $mailchimp = get_post_meta($post->ID, 'mailchimp-list-id', true);
+    $logged_in = mozilla_is_logged_in();
+
 ?>
     <div class="content">
         <div class="campaign">
@@ -32,8 +34,8 @@
                             - <?php print $campaign_end_date; ?>
                             <?php endif; ?>
                         </div>
-                        <?php if($campaign_hero_cta): ?>
-                        <a href="<?php print ($campaign_hero_cta_link) ? $campaign_hero_cta_link : '#'; ?>" class="campaign__hero-cta"><?php print $campaign_hero_cta; ?></a>
+                        <?php if($campaign_hero_cta && $logged_in): ?>
+                        <a href="<?php print ($campaign_hero_cta_link) ? $campaign_hero_cta_link : '#'; ?>" class="campaign__hero-cta"<?php if(isset($mailchimp->id)): ?> data-campaign="<?php print $mailchimp->id; ?>"<?php endif; ?>><?php print $campaign_hero_cta; ?></a>
                         <?php endif; ?>
                     </div>
                 </div>


### PR DESCRIPTION
You will need a campaign that has a mailchimp list associated with it and the hero cta copy must be filled out the campaign and be logged in.  To test just click the hero cta and check your mailchimp campaign to see if it's added.  It won't allow for duplicates.  Error handling hasn't been added so we'll need to add that and figure out what to do specifically it's not added.