### PR TITLE
Added endpoint to update discourse category

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -42,6 +42,8 @@ add_action('wp_ajax_nopriv_validate_group', 'mozilla_validate_group_name');
 add_action('wp_ajax_validate_group', 'mozilla_validate_group_name');
 add_action('wp_ajax_check_user', 'mozilla_validate_username');
 add_action('wp_ajax_delete_user', 'mozilla_delete_user');
+add_action('wp_ajax_update_group_discourse', 'mozilla_update_group_discourse_category_id');
+
 
 // Auth0 Actions
 add_action('auth0_user_login', 'mozilla_post_user_creation', 10, 6);

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -421,7 +421,43 @@ function mozilla_save_post($post_id, $post, $update) {
 
         update_post_meta($post_id, 'event-meta', $event);
     }
+}
 
+
+function mozilla_update_group_discourse_category_id() {
+
+    // Only site admins
+    if(!is_admin()) {
+        die('Invalid Permissions');
+    }
+
+    if(isset($_GET['group'])) {
+
+        $group_id = intval($_GET['group']);
+        $meta = groups_get_groupmeta($group_id, 'meta');
+        print "Before Meta Update<br>";
+        print "<pre>";
+        print_r($meta);
+        print "</pre>";
+
+        if(isset($_GET['category'])) {
+            $category_id = intval($_GET['category']);
+            
+            if(isset($meta['discourse_category_id'])) {
+                $meta['discourse_category_id'] = $category_id;
+            }
+
+            groups_update_groupmeta($group_id, 'meta', $meta);
+        }
+
+        print "After Meta Update<br>";
+        $meta = groups_get_groupmeta($group_id, 'meta');
+        print "<pre>";
+        print_r($meta);
+        print "</pre>";
+    }
+
+    die();
 }
 
 ?>


### PR DESCRIPTION
This feature allows admins to update a group's discourse category ID.  You must be an admin on the site to execute the, if you are not nothing will happen.

To test hit the following URL

/wp-admin/admin-ajax.php?action=update_group_discourse&group=<GROUP_ID>&category=<CATEGORY_ID>

You will need to provide two GET params group and category, representing the buddy press group id and the updated discourse category id respectively.  

Example call

`/wp-admin/admin-ajax.php?action=update_group_discourse&group=96&category=31`

The endpoint will display what the groups meta data looked like before the update and after the update.

While the updated meta data is a good indicator of whether the update went through you can also view the groups page to see if the discourse topics and links have updated to the new one. 