### PR TITLE
Removed group admins from events hosting panel

### DIFF
--- a/plugins/events-manager/templates/template-parts/event-single/event-host.php
+++ b/plugins/events-manager/templates/template-parts/event-single/event-host.php
@@ -5,73 +5,27 @@
 
     if ($EM_Event->group_id){
         $group = new BP_Groups_Group($EM_Event->group_id);
-        $admins = groups_get_group_admins($group->id);
-    }
+	}
+	$user_id = $EM_Event->event_owner;
+	$hosted_user = get_user_by('ID', $user_id);
+	$is_me = $logged_in && intval($current_user->ID) === intval($user_id);
+	$info = mozilla_get_user_info($current_user, $hosted_user, $logged_in);
+
+	if((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443) {
+		$avatar_url = preg_replace("/^http:/i", "https:", $info['profile_image']->value);
+	} else {
+		$avatar_url = $info['profile_image']->value;
+	}
 ?>
     <div class="row">
         <div class="<?php if (is_array($admins) && count($admins) < 2): echo __('col-lg-12 col-md-6'); else: echo __('events-single__hosts--multiple'); endif; ?> col-sm-12 events-single__hosts">
-            <p class="events-single__label"><?php echo __('Hosted by') ?></p>
-            <?php if (isset($group)): ?>
-            <a class="events-single__host" href="<?php echo get_site_url(null, 'groups/'.bp_get_group_slug($group)) ?>">
-                <?php echo bp_get_group_name($group) ?>
-            </a>
-            <?php endif; ?>
+				<p class="events-single__label"><?php echo __('Hosted by') ?></p>
+				<?php if (isset($group)): ?>
+					<a class="events-single__host" href="<?php echo get_site_url(null, 'groups/'.bp_get_group_slug($group)) ?>">
+						<?php echo bp_get_group_name($group) ?>
+					</a>
+				<?php endif; ?>
         </div>
-        <?php 
-            if ($EM_Event->group_id):
-                if (is_array($admins)) {
-                    foreach($admins AS $admin) {
-                        $a = get_user_by('ID', $admin->user_id);       
-
-                        $is_me = $logged_in && intval($current_user->ID) === intval($admin->user_id);
-                        $info = mozilla_get_user_info($current_user, $a, $logged_in);
-
-                        if((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443) {
-                            $avatar_url = preg_replace("/^http:/i", "https:", $info['profile_image']->value);
-                        } else {
-                            $avatar_url = $info['profile_image']->value;
-                        }
-        ?>
-        <div class="events-single__member-card col-lg-12 col-md-6 col-sm-12">
-            <a href="<?php echo esc_attr(get_site_url().'/people/'.$a->user_nicename)?>">
-                <div class="events-single__avatar<?php if($info['profile_image']->display === false || $info['profile_image']->value === false) : ?> members__avatar--identicon<?php endif; ?>" <?php if($info['profile_image']->display && $info['profile_image']->value): ?> style="background-image: url('<?php print $avatar_url; ?>')"<?php endif; ?> data-username="<?php print $a->user_nicename; ?>">
-                </div>
-                <p class="events-single__username"><?php echo $a->user_nicename; ?></p>
-                <?php if ($info['first_name']->display && $info['first_name']->value || $info['last_name']->display && $info['last_name']->value): ?>
-                <div class="events-single__name">
-                    <?php 
-                        if ($info['first_name']->display && $info['first_name']->value): 
-                            print $info['first_name']->value;
-                        endif; 
-
-                        if ($info['last_name']->display && $info['last_name']->value):
-                            print " {$info['last_name']->value}";
-                        endif; 
-                    ?>
-                </div>
-                <?php endif; ?>
-            </a>
-        </div>
-        <?php
-                    }
-                }
-        ?>
-        <?php else: ?>
-
-        <?php 
-            $user_id = $EM_Event->event_owner;
-            $hosted_user = get_user_by('ID', $user_id);
-          
-            $is_me = $logged_in && intval($current_user->ID) === intval($user_id);
-            $info = mozilla_get_user_info($current_user, $hosted_user, $logged_in);
-
-          
-            if((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443) {
-                $avatar_url = preg_replace("/^http:/i", "https:", $info['profile_image']->value);
-            } else {
-                $avatar_url = $info['profile_image']->value;
-            }
-        ?>
         <div class="events-single__member-card col-lg-12 col-md-6 col-sm-12">
             <a href="<?php echo '/people/'.$hosted_user->user_nicename; ?>">
                 <div class="events-single__avatar<?php if($info['profile_image']->display === false || $info['profile_image']->value === false) : ?> members__avatar--identicon<?php endif; ?>" <?php if($info['profile_image']->display && $info['profile_image']->value): ?> style="background-image: url('<?php print $avatar_url; ?>')"<?php endif; ?> data-username="<?php print $hosted_user->user_nicename; ?>">
@@ -92,7 +46,6 @@
                 <?php endif; ?>
             </a>
         </div>
-    <?php endif; ?>
     </div> 
     </div>
 </div>


### PR DESCRIPTION
Per this GitHub issues: https://github.com/mozilla/community-portal/issues/350

Removed group admins from events sidebar. Will now always serve event host. 