### PR TITLE
Added missing language Western Frisian

### DIFF
--- a/languages.php
+++ b/languages.php
@@ -642,6 +642,7 @@
         'vls'=> 'West Flemish',
         'bgn'=> 'Western Balochi',
         'cja'=> 'Western Cham',
+        'fy' => 'Western Frisian',
         'nhw'=> 'Western Huasteca Nahuat',
         'lcp'=> 'Western Lawa',
         'mrd'=> 'Western Magar',


### PR DESCRIPTION
Added missing language Western Frisian to language drop downs.

as per https://github.com/mozilla/community-portal/issues/349