### PR TITLE
Fix/moz 373 campaign mailchimp status bug

### DIFF
--- a/acf/acf-export-2020-03-11.json
+++ b/acf/acf-export-2020-03-11.json
@@ -1,0 +1,1514 @@
+
+
+[
+    {
+        "key": "group_5e287ad8bc529",
+        "title": "Campaign Fields",
+        "fields": [
+            {
+                "key": "field_5e690885116a8",
+                "label": "Mailchimp Integration",
+                "name": "mailchimp_integration",
+                "type": "true_false",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "Whether or not to create a Mailchimp audience with this campaign",
+                "default_value": 0,
+                "ui": 0,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
+                "key": "field_5e287aff0852a",
+                "label": "Hero CTA",
+                "name": "hero_cta",
+                "type": "text",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_5e58149991909",
+                "label": "Hero CTA Unsub",
+                "name": "hero_cta_unsub",
+                "type": "text",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "Unsubscribe",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_5e287b0a0852b",
+                "label": "Hero CTA link",
+                "name": "hero_cta_link",
+                "type": "url",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": ""
+            },
+            {
+                "key": "field_5e287b2647128",
+                "label": "Campaign Start Date",
+                "name": "campaign_start_date",
+                "type": "date_picker",
+                "instructions": "",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "display_format": "m\/d\/Y",
+                "return_format": "F j, Y",
+                "first_day": 1
+            },
+            {
+                "key": "field_5e287b9047129",
+                "label": "Campaign End Date",
+                "name": "campaign_end_date",
+                "type": "date_picker",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "display_format": "m\/d\/Y",
+                "return_format": "F j, Y",
+                "first_day": 1
+            },
+            {
+                "key": "field_5e287bac4712a",
+                "label": "Campaign Status",
+                "name": "campaign_status",
+                "type": "select",
+                "instructions": "",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "choices": {
+                    "Active": "Active",
+                    "Closed": "Closed"
+                },
+                "default_value": [
+                    "Active"
+                ],
+                "allow_null": 0,
+                "multiple": 0,
+                "ui": 0,
+                "return_format": "value",
+                "ajax": 0,
+                "placeholder": ""
+            },
+            {
+                "key": "field_5e2892743bb3e",
+                "label": "Campaign Content",
+                "name": "campaign_content",
+                "type": "flexible_content",
+                "instructions": "Add Campaign Content",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layouts": {
+                    "layout_5e28a1140d1df": {
+                        "key": "layout_5e28a1140d1df",
+                        "name": "text_1up_block",
+                        "label": "Text 1UP Block",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5e289fce3bb3f",
+                                "label": "Title",
+                                "name": "title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28a0051f69d",
+                                "label": "Background Color",
+                                "name": "background_color",
+                                "type": "radio",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "white": "White",
+                                    "grey": "Grey"
+                                },
+                                "allow_null": 0,
+                                "other_choice": 0,
+                                "default_value": "white",
+                                "layout": "vertical",
+                                "return_format": "value",
+                                "save_other_choice": 0
+                            },
+                            {
+                                "key": "field_5e28a21561493",
+                                "label": "Copy",
+                                "name": "copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 0,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e28b0035b814",
+                                "label": "CTA",
+                                "name": "cta",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28b00d5b815",
+                                "label": "CTA Link",
+                                "name": "cta_link",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e28c232c5d47",
+                                "label": "Keyline",
+                                "name": "keyline",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Show keyline above block",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "layout_5e28a1f961492": {
+                        "key": "layout_5e28a1f961492",
+                        "name": "text_2up_block",
+                        "label": "Text 2UP Block",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5e28a24502768",
+                                "label": "Title",
+                                "name": "title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28a24c02769",
+                                "label": "Background Color",
+                                "name": "background_color",
+                                "type": "radio",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "white": "White",
+                                    "grey": "Grey"
+                                },
+                                "allow_null": 0,
+                                "other_choice": 0,
+                                "default_value": "white",
+                                "layout": "vertical",
+                                "return_format": "value",
+                                "save_other_choice": 0
+                            },
+                            {
+                                "key": "field_5e28a2b7ce11a",
+                                "label": "Column 1 Title",
+                                "name": "column_1_title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28b7053e53f",
+                                "label": "Column 1 Copy",
+                                "name": "column_1_copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 0,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e28bd172ba68",
+                                "label": "Column 1 CTA",
+                                "name": "column_1_cta",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28bd222ba69",
+                                "label": "Column 1 CTA Link",
+                                "name": "column_1_cta_link",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e28a2e4ce11b",
+                                "label": "Column 2 Title",
+                                "name": "column_2_title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28b7143e540",
+                                "label": "Column 2 Copy",
+                                "name": "column_2_copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 1,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e28bd2e2ba6a",
+                                "label": "Column 2 CTA",
+                                "name": "column_2_cta",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28bd332ba6b",
+                                "label": "Column 2 CTA Link",
+                                "name": "column_2_cta_link",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e28c267c5d49",
+                                "label": "Keyline",
+                                "name": "keyline",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Show keyline above block",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "layout_5e28beb01ee9b": {
+                        "key": "layout_5e28beb01ee9b",
+                        "name": "text_3up_block",
+                        "label": "Text 3UP Block",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5e28bf351ee9c",
+                                "label": "Title",
+                                "name": "title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28bf3c1ee9d",
+                                "label": "Background Color",
+                                "name": "background_color",
+                                "type": "radio",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "white": "White",
+                                    "grey": "Grey"
+                                },
+                                "allow_null": 0,
+                                "other_choice": 0,
+                                "default_value": "",
+                                "layout": "vertical",
+                                "return_format": "value",
+                                "save_other_choice": 0
+                            },
+                            {
+                                "key": "field_5e28bf5e1ee9e",
+                                "label": "Column 1 Title",
+                                "name": "column_1_title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28bf791ee9f",
+                                "label": "Column 1 Copy",
+                                "name": "column_1_copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 0,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e28bf851eea0",
+                                "label": "Column 1 CTA",
+                                "name": "column_1_cta",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28bf8d1eea1",
+                                "label": "Column 1 CTA Link",
+                                "name": "column_1_cta_link",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e28bfa21eea2",
+                                "label": "Column 2 Title",
+                                "name": "column_2_title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28bfb11eea3",
+                                "label": "Column 2 Copy",
+                                "name": "column_2_copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 0,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e28bfc01eea4",
+                                "label": "Column 2 CTA",
+                                "name": "column_2_cta",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28bfc71eea5",
+                                "label": "Column 2 CTA Link",
+                                "name": "column_2_cta_link",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e28bfd81eea6",
+                                "label": "Column 3 Title",
+                                "name": "column_3_title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28bfde1eea7",
+                                "label": "Column 3 Copy",
+                                "name": "column_3_copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 0,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e28bfea1eea8",
+                                "label": "Column 3 CTA",
+                                "name": "column_3_cta",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28bff21eea9",
+                                "label": "Column 3 CTA Link",
+                                "name": "column_3_cta_link",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e28c27ac5d4a",
+                                "label": "Keyline",
+                                "name": "keyline",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Show keyline above block",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "layout_5e28e4a0ebde3": {
+                        "key": "layout_5e28e4a0ebde3",
+                        "name": "text_image",
+                        "label": "Text Image",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5e28e4b2ebde4",
+                                "label": "Title",
+                                "name": "title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e28ecd98c13c",
+                                "label": "Background Color",
+                                "name": "background_color",
+                                "type": "radio",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "white": "White",
+                                    "grey": "Grey"
+                                },
+                                "allow_null": 0,
+                                "other_choice": 0,
+                                "default_value": "",
+                                "layout": "vertical",
+                                "return_format": "value",
+                                "save_other_choice": 0
+                            },
+                            {
+                                "key": "field_5e28e4bfebde5",
+                                "label": "Copy",
+                                "name": "copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 0,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e28e4cfebde6",
+                                "label": "image",
+                                "name": "image",
+                                "type": "image",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "return_format": "array",
+                                "preview_size": "medium",
+                                "library": "all",
+                                "min_width": "",
+                                "min_height": "",
+                                "min_size": "",
+                                "max_width": "",
+                                "max_height": "",
+                                "max_size": "",
+                                "mime_types": ""
+                            },
+                            {
+                                "key": "field_5e28e4e9ebde7",
+                                "label": "keyline",
+                                "name": "keyline",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Display keyline above block",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "layout_5e2905d227ce4": {
+                        "key": "layout_5e2905d227ce4",
+                        "name": "text_card",
+                        "label": "Text Card",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5e2905e427ce5",
+                                "label": "title",
+                                "name": "title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e2905ea27ce6",
+                                "label": "Copy",
+                                "name": "copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 0,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e290b21288b4",
+                                "label": "keyline",
+                                "name": "keyline",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Display keyline above block",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "layout_5e290bc7668ed": {
+                        "key": "layout_5e290bc7668ed",
+                        "name": "events_block",
+                        "label": "Events Block",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5e290c6ba3d1e",
+                                "label": "Title",
+                                "name": "title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e290bd2668ee",
+                                "label": "Events",
+                                "name": "events",
+                                "type": "repeater",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "collapsed": "field_5e290be8668ef",
+                                "min": 0,
+                                "max": 4,
+                                "layout": "table",
+                                "button_label": "",
+                                "sub_fields": [
+                                    {
+                                        "key": "field_5e290be8668ef",
+                                        "label": "event",
+                                        "name": "event",
+                                        "type": "post_object",
+                                        "instructions": "",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "post_type": [
+                                            "event"
+                                        ],
+                                        "taxonomy": "",
+                                        "allow_null": 0,
+                                        "multiple": 0,
+                                        "return_format": "object",
+                                        "ui": 1
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "field_5e29eb459c8ac",
+                                "label": "Keyline",
+                                "name": "keyline",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Display keyline above block",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "layout_5e29f90e27c3b": {
+                        "key": "layout_5e29f90e27c3b",
+                        "name": "video_block",
+                        "label": "Video Block",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5e29f91727c3c",
+                                "label": "Title",
+                                "name": "title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e29f9fbb26c5",
+                                "label": "Background Color",
+                                "name": "background_color",
+                                "type": "select",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "white": "White",
+                                    "grey": "Grey"
+                                },
+                                "default_value": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "ui": 0,
+                                "return_format": "value",
+                                "ajax": 0,
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e29f92127c3d",
+                                "label": "Copy",
+                                "name": "copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 0,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e29f94127c3e",
+                                "label": "CTA",
+                                "name": "cta",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e29f94527c3f",
+                                "label": "CTA Link",
+                                "name": "cta_link",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e29f94d27c40",
+                                "label": "Youtube Video URL",
+                                "name": "video",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "Youtube URL"
+                            },
+                            {
+                                "key": "field_5e29f9e4b26c4",
+                                "label": "Keyline",
+                                "name": "keyline",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Display keyline above block",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "layout_5e2a012e5e4ce": {
+                        "key": "layout_5e2a012e5e4ce",
+                        "name": "imagery_block",
+                        "label": "Imagery Block",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5e2a01355e4cf",
+                                "label": "Title",
+                                "name": "title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e2a01445e4d0",
+                                "label": "Background Color",
+                                "name": "background_color",
+                                "type": "select",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "white": "White",
+                                    "grey": "Grey"
+                                },
+                                "default_value": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "ui": 0,
+                                "return_format": "value",
+                                "ajax": 0,
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e2a03035e4d1",
+                                "label": "Copy",
+                                "name": "copy",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 0,
+                                "delay": 0
+                            },
+                            {
+                                "key": "field_5e2a03135e4d2",
+                                "label": "images",
+                                "name": "images",
+                                "type": "repeater",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "collapsed": "",
+                                "min": 2,
+                                "max": 0,
+                                "layout": "table",
+                                "button_label": "",
+                                "sub_fields": [
+                                    {
+                                        "key": "field_5e2a03235e4d3",
+                                        "label": "image",
+                                        "name": "image",
+                                        "type": "image",
+                                        "instructions": "",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "return_format": "array",
+                                        "preview_size": "medium",
+                                        "library": "all",
+                                        "min_width": "",
+                                        "min_height": "",
+                                        "min_size": "",
+                                        "max_width": "",
+                                        "max_height": "",
+                                        "max_size": "",
+                                        "mime_types": ""
+                                    },
+                                    {
+                                        "key": "field_5e2a033e5e4d4",
+                                        "label": "Caption",
+                                        "name": "caption",
+                                        "type": "text",
+                                        "instructions": "",
+                                        "required": 0,
+                                        "conditional_logic": 0,
+                                        "wrapper": {
+                                            "width": "",
+                                            "class": "",
+                                            "id": ""
+                                        },
+                                        "default_value": "",
+                                        "placeholder": "",
+                                        "prepend": "",
+                                        "append": "",
+                                        "maxlength": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "key": "field_5e2a034b5e4d5",
+                                "label": "Keyline",
+                                "name": "keyline",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Display keyline above block",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "layout_5e2a4ab149859": {
+                        "key": "layout_5e2a4ab149859",
+                        "name": "outro_cta_block",
+                        "label": "Outro CTA Block",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5e2a4acd4985a",
+                                "label": "title",
+                                "name": "title",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e2a4ad24985b",
+                                "label": "CTA",
+                                "name": "cta",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
+                            },
+                            {
+                                "key": "field_5e2a4ae24985c",
+                                "label": "CTA Link",
+                                "name": "cta_link",
+                                "type": "url",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e2a4aea4985d",
+                                "label": "Background Color",
+                                "name": "background_color",
+                                "type": "select",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "choices": {
+                                    "white": "White",
+                                    "grey": "Grey"
+                                },
+                                "default_value": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "ui": 0,
+                                "return_format": "value",
+                                "ajax": 0,
+                                "placeholder": ""
+                            },
+                            {
+                                "key": "field_5e2a4b0e4985e",
+                                "label": "keyline",
+                                "name": "keyline",
+                                "type": "true_false",
+                                "instructions": "",
+                                "required": 0,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "message": "Display keyline above block",
+                                "default_value": 0,
+                                "ui": 0,
+                                "ui_on_text": "",
+                                "ui_off_text": ""
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    }
+                },
+                "button_label": "Add Content",
+                "min": "",
+                "max": ""
+            },
+            {
+                "key": "field_5e2f0d4aef2e3",
+                "label": "Card Description",
+                "name": "card_description",
+                "type": "wysiwyg",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 0,
+                "delay": 0
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "post_type",
+                    "operator": "==",
+                    "value": "campaign"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    }
+]

--- a/lib/api.php
+++ b/lib/api.php
@@ -224,56 +224,62 @@ function mozilla_discourse_get_category_topics($url) {
 
 function mozilla_create_mailchimp_list($campaign) {
     $options = wp_load_alloptions();
+    
+    $create_audience = get_field('mailchimp_integration', $campaign->ID);
 
-    if(isset($options['mailchimp'])) {
+    if($create_audience && isset($options['mailchimp'])) {
         $apikey = trim($options['mailchimp']);
         $dc = substr($apikey, -3);
         if($dc) {
-            
-            $curl = curl_init();
-            $api_url = "https://{$dc}.api.mailchimp.com/3.0/lists";
+            $mailchimp_check = get_post_meta($campaign->ID, 'mailchimp-list-id', true);
 
-            $auth_string = "user:{$apikey}";
-            $auth = base64_encode($auth_string);
+            if(empty($mailchimp_check)) {
 
-            curl_setopt($curl, CURLOPT_URL, $api_url);
-            curl_setopt($curl, CURLOPT_HTTPHEADER, Array("Content-Type: application/json"));
-            curl_setopt($curl, CURLOPT_USERPWD, 'user:' . $apikey);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($curl, CURLOPT_POST, true);
+                $curl = curl_init();
+                $api_url = "https://{$dc}.api.mailchimp.com/3.0/lists";
 
-            $campaign_list_name = "{$campaign->post_title} - Mozilla";
-            
-            $data = Array();
-            $data['name'] = $campaign_list_name;
+                $auth_string = "user:{$apikey}";
+                $auth = base64_encode($auth_string);
 
-            $data['contact'] = Array(
-                'company'   =>  $options['company'],
-                'address1'  =>  $options['address'],
-                'city'      =>  $options['city'],
-                'state'     =>  $options['state'],
-                'zip'       =>  $options['zip'],
-                'country'   =>  $options['country'],
-                'phone'     =>  $options['phone']
-            );
+                curl_setopt($curl, CURLOPT_URL, $api_url);
+                curl_setopt($curl, CURLOPT_HTTPHEADER, Array("Content-Type: application/json"));
+                curl_setopt($curl, CURLOPT_USERPWD, 'user:' . $apikey);
+                curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt($curl, CURLOPT_POST, true);
 
-            $data['campaign_defaults'] = Array(
-                'from_name'     =>  $campaign_list_name,
-                'from_email'    =>  $options['report_email'],
-                'subject'       =>  $campaign_list_name,
-                'language'      =>  'English'
-            );
+                $campaign_list_name = "{$campaign->post_title} - Mozilla";
+                
+                $data = Array();
+                $data['name'] = $campaign_list_name;
 
-            $data['permission_reminder'] = "You are participating in the Mozilla {$campaign->post_title} campaign";
-            $data['email_type_option'] = true;
+                $data['contact'] = Array(
+                    'company'   =>  $options['company'],
+                    'address1'  =>  $options['address'],
+                    'city'      =>  $options['city'],
+                    'state'     =>  $options['state'],
+                    'zip'       =>  $options['zip'],
+                    'country'   =>  $options['country'],
+                    'phone'     =>  $options['phone']
+                );
 
-            $json = json_encode($data);
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
-            $result = curl_exec($curl);
-            curl_close($curl);
+                $data['campaign_defaults'] = Array(
+                    'from_name'     =>  $campaign_list_name,
+                    'from_email'    =>  $options['report_email'],
+                    'subject'       =>  $campaign_list_name,
+                    'language'      =>  'English'
+                );
 
-            $json_result = json_decode($result);
-            return update_post_meta($campaign->ID, 'mailchimp-list-id', $json_result);
+                $data['permission_reminder'] = "You are participating in the Mozilla {$campaign->post_title} campaign";
+                $data['email_type_option'] = true;
+
+                $json = json_encode($data);
+                curl_setopt($curl, CURLOPT_POSTFIELDS, $json);
+                $result = curl_exec($curl);
+                curl_close($curl);
+
+                $json_result = json_decode($result);
+                return update_post_meta($campaign->ID, 'mailchimp-list-id', $json_result);
+            }
         }
     }
 

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -466,10 +466,7 @@ function mozilla_update_group_discourse_category_id() {
 
 function mozilla_post_status_transition($new_status, $old_status, $post) { 
 
-    if($new_status == 'publish' && 
-        $old_status == 'auto-draft' && 
-        !wp_is_post_revision($post->ID) && 
-        !wp_is_post_autosave($post->ID)) 
+    if($new_status == 'publish')
     {
         if($post->post_type === 'campaign') {            
             mozilla_create_mailchimp_list($post);

--- a/single-campaign.php
+++ b/single-campaign.php
@@ -45,14 +45,12 @@
                             - <?php print $campaign_end_date; ?>
                             <?php endif; ?>
                         </div>
-                        <?php if($campaign_hero_cta && $logged_in && $mailchimp && isset($mailchimp->id)): ?>
+                        <?php if(($campaign_hero_cta && $logged_in && $mailchimp && isset($mailchimp->id)) || is_preview()): ?>
                         <a href="<?php print ($campaign_hero_cta_link) ? $campaign_hero_cta_link : '#'; ?>" class="campaign__hero-cta<?php if($mailchimp && isset($mailchimp->id) && $sub === true): ?> campaign__hero-cta--sub<?php else: ?> campaign__hero-cta--unsub<?php endif; ?>"<?php if($mailchimp && isset($mailchimp->id)): ?><?php if($mailchimp): ?> data-list="<?php print $mailchimp->id; ?>"<?php endif; ?><?php endif; ?> data-unsub-copy="<?php print $campaign_hero_unsub_cta; ?>" data-sub-copy="<?php print $campaign_hero_cta; ?>" data-campaign="<?php print $post->ID;?>"><?php print $sub ? $campaign_hero_cta : $campaign_hero_unsub_cta; ?></a>
                         <?php endif; ?>
                     </div>
                 </div>
             </div>
-			<?php if (isset($mailchimp_info->id) && strlen($mailchimp_info->id) > 0): ?>
-			<?php endif; ?>
             <div class="campaign__intro">
                 <div class="campaign__intro-card">
                     <?php print $post->post_content; ?>


### PR DESCRIPTION
The Mailchimp create audience API will now fire whenever a campaign is published and the new Mailchimp integration checkbox is checked.

You will need to import the new ACF field from the file acf-export-2020-03-11.json

You should test if you are able to preview blocks for a campaign in draft mode and if it creates the Mailchimp audience when you change the campaign post status to publish.  It should not fire if the campaign already has a audience associated with it