### PR TITLE
Added language dimension to groups create and edit

### DIFF
--- a/buddypress/groups/index-create.php
+++ b/buddypress/groups/index-create.php
@@ -82,7 +82,7 @@
                             <div class="create-group__input-container create-group__input-container--full create-group__input-container--vertical-spacing">
                                 <label class="create-group__label" for="group-language"><?php print __("Language", "community-portal"); ?></label>
                                 <div class="create-group__select-container">
-                                    <select id="group-language" class="create-group__select" name="group_language" required>
+                                    <select id="group-language" class="create-group__select" name="group_language">
                                         <option value="0"><?php print __("Language", "community-portal"); ?></option>
                                         <?php foreach($languages AS $code =>  $language_name): ?>
                                         <option value="<?php print $code; ?>"<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($form['group_language']) && $form['group_language'] == $code): ?> selected<?php endif; ?>><?php print $language_name; ?></option>

--- a/buddypress/groups/index-create.php
+++ b/buddypress/groups/index-create.php
@@ -1,6 +1,7 @@
 <?php
     session_start();
     do_action('bp_before_create_group_page');
+
     $user = wp_get_current_user();
     $meta = get_user_meta($user->ID);
 
@@ -23,6 +24,7 @@
 
     $template_dir = get_template_directory();
     include("{$template_dir}/countries.php");
+    include("{$template_dir}/languages.php");
 
     if(isset($_SESSION['form'])) {
         $form = $_SESSION['form'];
@@ -75,6 +77,19 @@
                                     </select>
                                 </div>
 							</div>
+                        </div>
+                        <div class="create-group__input-row">
+                            <div class="create-group__input-container create-group__input-container--full create-group__input-container--vertical-spacing">
+                                <label class="create-group__label" for="group-language"><?php print __("Language", "community-portal"); ?></label>
+                                <div class="create-group__select-container">
+                                    <select id="group-language" class="create-group__select" name="group_language" required>
+                                        <option value="0"><?php print __("Language", "community-portal"); ?></option>
+                                        <?php foreach($languages AS $code =>  $language_name): ?>
+                                        <option value="<?php print $code; ?>"<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($form['group_language']) && $form['group_language'] == $code): ?> selected<?php endif; ?>><?php print $language_name; ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                            </div>
                         </div>
                         <div class="create-group__input-row">
                             <div class="create-group__input-container  create-group__input-container--40 create-group__input-container--vertical-spacing">

--- a/buddypress/groups/single/edit.php
+++ b/buddypress/groups/single/edit.php
@@ -5,6 +5,9 @@
     $group_meta = groups_get_groupmeta($group_id, 'meta');
     $group_admins = groups_get_group_admins($group_id);
 
+
+    
+
     if($_SERVER['REQUEST_METHOD'] === 'POST') {
         $form = $_POST;
 
@@ -16,6 +19,7 @@
         $form['group_name'] = $group->name;
         $form['group_desc'] = $group->description;
         $form['group_type'] = isset($group_meta['group_type']) ? $group_meta['group_type'] : 'Online';
+        $form['group_language'] = isset($group_meta['group_language']) ? $group_meta['group_language'] : '0';
         $form['group_country'] = isset($group_meta['group_country']) ? $group_meta['group_country'] : '0';
         $form['group_city'] = isset($group_meta['group_city']) ? $group_meta['group_city'] : '';
         $form['image_url'] = isset($group_meta['group_image_url']) ? $group_meta['group_image_url'] : '';
@@ -82,6 +86,19 @@
                             <select id="group-type" class="create-group__select" name="group_type" required>
                                 <option value="Online"<?php if(isset($form['group_type']) && $form['group_type'] == 'Online' || (empty($form['group_type']))): ?> selected<?php endif; ?>><?php print __("Online", "community-portal"); ?></option>
                                 <option value="Offline"<?php if(isset($form['group_type']) && $form['group_type'] == 'Offline'): ?> selected<?php endif; ?>><?php print __("Offline", "community-portal"); ?></option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+                <div class="create-group__input-row">
+                    <div class="create-group__input-container create-group__input-container--full create-group__input-container--vertical-spacing">
+                        <label class="create-group__label" for="group-language"><?php print __("Language", "community-portal"); ?></label>
+                        <div class="create-group__select-container">
+                            <select id="group-language" class="create-group__select" name="group_language" required>
+                                <option value="0"><?php print __("Language", "community-portal"); ?></option>
+                                <?php foreach($languages AS $code =>  $language_name): ?>
+                                <option value="<?php print $code; ?>"<?php if(isset($form['group_language']) && $form['group_language'] == $code): ?> selected<?php endif; ?>><?php print $language_name; ?></option>
+                                <?php endforeach; ?>
                             </select>
                         </div>
                     </div>

--- a/buddypress/groups/single/edit.php
+++ b/buddypress/groups/single/edit.php
@@ -94,7 +94,7 @@
                     <div class="create-group__input-container create-group__input-container--full create-group__input-container--vertical-spacing">
                         <label class="create-group__label" for="group-language"><?php print __("Language", "community-portal"); ?></label>
                         <div class="create-group__select-container">
-                            <select id="group-language" class="create-group__select" name="group_language" required>
+                            <select id="group-language" class="create-group__select" name="group_language">
                                 <option value="0"><?php print __("Language", "community-portal"); ?></option>
                                 <?php foreach($languages AS $code =>  $language_name): ?>
                                 <option value="<?php print $code; ?>"<?php if(isset($form['group_language']) && $form['group_language'] == $code): ?> selected<?php endif; ?>><?php print $language_name; ?></option>

--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -658,6 +658,22 @@
                                 </div>
                             </div>
                         </div>
+                        <?php 
+
+                        
+                        ?>
+                        <?php if(strlen($group_meta['group_language']) > 0 && array_key_exists(strtolower($group_meta['group_language']), $languages)): ?>
+                        <div class="group__card">
+                            <div class="group__card-content group__card-content--small">
+                                <span><?php print __('Preferred Language', "community-portal"); ?></span>
+                                <div class="group__tags">
+                                    <div class="group__language">
+                                        <?php print $languages[strtolower($group_meta['group_language'])]; ?>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <?php endif; ?>
                         <?php if(sizeof(array_unique($group_meta['group_tags'])) > 0): ?>
                         <div class="group__card">
                             <div class="group__card-content group__card-content--small">

--- a/buddypress/groups/single/home.php
+++ b/buddypress/groups/single/home.php
@@ -23,7 +23,7 @@
     $theme_directory = get_template_directory();
 
     include("{$theme_directory}/countries.php");
-
+    include("{$theme_directory}/languages.php");
 
     if($edit_group) {
 

--- a/js/groups.js
+++ b/js/groups.js
@@ -263,6 +263,7 @@ jQuery(function(){
 
     jQuery('.groups__search-cta').click(function(e) {
         jQuery('input[name="tag"]').prop('disabled', true);
+        jQuery('input[name="language"]').prop('disabled', true);
         jQuery('input[name="location"]').prop('disabled', true);
         jQuery('input[name="mygroups"]').prop('disabled', true);
 
@@ -278,6 +279,30 @@ jQuery(function(){
     jQuery('.groups__location-select').change(function(e) {
         var location = jQuery(this).val();
         jQuery('input[name="location"]').val(location);
+
+        if(jQuery('input[name="tag"]').val().length === 0) {
+            jQuery('input[name="tag"]').prop('disabled', true);
+        }
+
+        if(jQuery('input[name="language"]').val().length === 0) {
+            jQuery('input[name="language"]').prop('disabled', true);
+        }
+
+        if(jQuery('input[name="mygroups"]').val() == 'false') {
+            jQuery('input[name="mygroups"]').prop('disabled', true);
+        }
+
+        jQuery('#group-search-form').submit();
+
+    });
+
+    jQuery('.groups__language-select').change(function(e) {
+        var language = jQuery(this).val();
+        jQuery('input[name="language"]').val(language);
+
+        if(jQuery('input[name="location"]').val().length === 0) {
+            jQuery('input[name="location"]').prop('disabled', true);
+        }
 
         if(jQuery('input[name="tag"]').val().length === 0) {
             jQuery('input[name="tag"]').prop('disabled', true);

--- a/lib/groups.php
+++ b/lib/groups.php
@@ -27,7 +27,8 @@ function mozilla_create_group() {
             'group_twitter',
             'group_other',
             'group_country',
-            'group_city'
+            'group_city',
+            'group_language'
         );
 
         // If we're posting data lets create a group
@@ -251,7 +252,7 @@ function mozilla_edit_group() {
                     $meta['group_city'] = isset($_POST['group_city']) ? sanitize_text_field($_POST['group_city']) : '';
                     $meta['group_country'] = isset($_POST['group_country']) ? sanitize_text_field($_POST['group_country']): '';
                     $meta['group_type'] = isset($_POST['group_type']) ? sanitize_text_field($_POST['group_type']) : 'Online';
-                    
+                    $meta['group_language'] = isset($_POST['group_language']) ? sanitize_text_field($_POST['group_language']) : '';
 
                     if(isset($_POST['tags'])) {
                         $tags = array_filter(explode(',', $_POST['tags']));

--- a/scss/_group.scss
+++ b/scss/_group.scss
@@ -850,4 +850,10 @@
             margin-right: 8px;
         }
     }
+
+    &__language {
+        color: $color-gray-80;
+        font-size: remCalc(14);
+        line-height: 20px;
+    }
 }

--- a/scss/_groups.scss
+++ b/scss/_groups.scss
@@ -294,6 +294,7 @@
         @include desktop-and-up {
             flex-wrap: nowrap;
             margin-left: 16px;    
+            max-width: 30%;
             width: auto;
         }
     }
@@ -318,6 +319,7 @@
         text-decoration: none;
     }
 
+    
     &__location-select {
         appearance: none;
         background: $color-gray-20;
@@ -334,6 +336,25 @@
         @include tablet-and-up {
             margin-right: 16px;
         }
+
+        @include desktop-and-up {
+            margin-right: 0;
+            width: 100%;
+        }
+    }
+
+    &__language-select {
+        appearance: none;
+        background: $color-gray-20;
+        background-image: url('data:image/svg+xml;charset=UTF-8,<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g><path d="M8.12499 9L12.005 12.88L15.885 9C16.275 8.61 16.905 8.61 17.295 9C17.685 9.39 17.685 10.02 17.295 10.41L12.705 15C12.315 15.39 11.685 15.39 11.295 15L6.70499 10.41C6.51774 10.2232 6.41251 9.96952 6.41251 9.705C6.41251 9.44048 6.51774 9.18683 6.70499 9C7.09499 8.62 7.73499 8.61 8.12499 9Z" fill="black" fill-opacity="0.54"/></g></svg>');
+        background-position: calc(100% - 10px) center;
+        background-repeat: no-repeat;
+        background-size: 25px;
+        border: none;
+        box-sizing: border-box;
+        padding: 8px 16px;
+        -webkit-appearance: none;
+        width: 100%;
 
         @include desktop-and-up {
             margin-right: 0;

--- a/scss/_groups.scss
+++ b/scss/_groups.scss
@@ -595,4 +595,6 @@
         display: inline;
         text-decoration: none;
     }
+
+
 }


### PR DESCRIPTION
This is based off of PR https://github.com/mozilla/community-portal/pull/376.  This adds the language dimension to both the create and edit forms for groups. I suggest reviewing that PR first.

We have yet to decide where to display these new dimensions.  But this will at the very least save them to meta data.

