### PR TITLE
dont randomize on paging

### DIFF
--- a/buddypress/groups/index-directory.php
+++ b/buddypress/groups/index-directory.php
@@ -1,6 +1,6 @@
 <?php 
     // Override the buddypress group listing page template
-
+    session_start();
     // Main header template 
     get_header(); 
 
@@ -169,8 +169,7 @@
     
     // Only Randomize on first page
 
-    if($page === 1) {
-
+    if($p == 1) {
         unset($_SESSION['verified_groups']);
         unset($_SESSION['unverified_groups']);
 
@@ -180,13 +179,14 @@
         $_SESSION['verified_groups'] = $verified_groups;
         $_SESSION['unverified_groups'] = $unverified_groups;
     } else {
-
-        if(isset($_SESSION['verified_groups']))
+        
+        if(isset($_SESSION['verified_groups'])) {
             $verified_groups = $_SESSION['verified_groups'];
+        }
         
-        if(isset($_SESSION['unverified_groups']))
+        if(isset($_SESSION['unverified_groups'])) {
             $unverified_groups = $_SESSION['unverified_groups'];
-        
+        }
     }
 
     $filtered_groups = array_merge($verified_groups, $unverified_groups);

--- a/buddypress/groups/index-directory.php
+++ b/buddypress/groups/index-directory.php
@@ -167,9 +167,27 @@
         }
     }
     
-    // Randomize
-    shuffle($verified_groups);
-    shuffle($unverified_groups);
+    // Only Randomize on first page
+
+    if($page === 1) {
+
+        unset($_SESSION['verified_groups']);
+        unset($_SESSION['unverified_groups']);
+
+        shuffle($verified_groups);
+        shuffle($unverified_groups);
+
+        $_SESSION['verified_groups'] = $verified_groups;
+        $_SESSION['unverified_groups'] = $unverified_groups;
+    } else {
+
+        if(isset($_SESSION['verified_groups']))
+            $verified_groups = $_SESSION['verified_groups'];
+        
+        if(isset($_SESSION['unverified_groups']))
+            $unverified_groups = $_SESSION['unverified_groups'];
+        
+    }
 
     $filtered_groups = array_merge($verified_groups, $unverified_groups);
 


### PR DESCRIPTION
Don't randomize groups on paging.  The list should stay in tact as you page up and down.  Using session to store this.