### PR TITLE
Added debug code

### DIFF
--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -717,6 +717,22 @@
                     </a>
                 </div>
                 <?php endif; ?>
+                <?php if(in_array('administrator',  wp_get_current_user()->roles)): ?>
+                <a href="#" id="group-show-debug-info" class="group__show-debug-info">Show Meta Data</a>
+                <div class="group__debug-info group__debug-info--hidden">
+                    <h3>Debug Information</h3>
+
+                    Discourse Group Information
+                    <pre>
+                        <?php print_r($discourse_group); ?>
+                    </pre>
+
+                    Group Meta
+                    <pre>
+                        <?php print_r($group_meta); ?>
+                    </pre>
+                </div>
+                <?php endif; ?>
             </div>
         </div>
     </div>

--- a/js/events.js
+++ b/js/events.js
@@ -348,5 +348,14 @@ jQuery(function() {
         handleOnlineEvent();
     }
 
+
+    jQuery('#events-show-debug-info').click(function(e){
+        e.preventDefault();
+        jQuery('.events-single__debug-info').toggleClass('events-single__debug-info--hidden');
+        return false;
+
+
+    });
+
     init();
 });

--- a/js/groups.js
+++ b/js/groups.js
@@ -411,4 +411,10 @@ jQuery(function(){
 
     });
 
+    jQuery('#group-show-debug-info').click(function(e){
+        e.preventDefault();
+        jQuery('.group__debug-info').toggleClass('group__debug-info--hidden');
+        return false;
+    });
+
 });

--- a/lib/api.php
+++ b/lib/api.php
@@ -7,13 +7,14 @@ function mozilla_get_discourse_info($id, $type = 'group') {
     if($type === 'event') {
         if($id) {
             $event_meta = get_post_meta($id, 'event-meta');
-
+            
             if(!empty($event_meta) && isset($event_meta[0]->discourse_group_id)) { 
                 $data = Array();
                 $data['group_id'] = $event_meta[0]->discourse_group_id;
                 $discourse_group = mozilla_discourse_api('groups', $data, 'get');
                 $discourse_info['discourse_group_id'] = $data['group_id'];
-                
+            
+
                 if($discourse_group && !isset($discourse_group->status)) {
 
                     $discourse_info['discourse_group_name'] = $discourse_group->name;

--- a/lib/campaigns.php
+++ b/lib/campaigns.php
@@ -1,11 +1,6 @@
 
 <?php 
 
-
-
-print_r($languages);
-
-
 function mozilla_mailchimp_unsubscribe() {
     if($_SERVER['REQUEST_METHOD'] === 'POST') {
 		if(isset($_POST['list']) && strlen($_POST['list']) > 0) {

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -510,7 +510,6 @@ function mozilla_post_status_transition($new_status, $old_status, $post) {
             mozilla_create_mailchimp_list($post);
         }    
     } 
-
 } 
 
 function mozilla_export_users() {

--- a/plugins/events-manager/templates/event-single.php
+++ b/plugins/events-manager/templates/event-single.php
@@ -12,6 +12,7 @@
     
     $categories = get_the_terms($EM_Event->post_id, EM_TAXONOMY_CATEGORY);  
     $event_meta = get_post_meta($EM_Event->post_id, 'event-meta');
+
     $allCountries = em_get_countries();
     $img_url = $event_meta[0]->image_url;
 
@@ -28,6 +29,10 @@
 	$goal = isset($event_meta[0]->goal) && strlen($event_meta[0]->goal) > 0 ? $event_meta[0]->goal : false;
 	$language = isset($event_meta[0]->language) && strlen($event_meta[0]->language) > 0 ? $languages[$event_meta[0]->language] : false;
 	$projected_attendees = isset($event_meta[0]->projected_attendees) && intval($event_meta[0]->projected_attendees) > 0 ? $event_meta[0]->projected_attendees : false;
+
+
+    
+
 
     $months = array(
         '01' => 'January',
@@ -89,6 +94,8 @@
             $users = get_current_user_id();
         }
     }
+
+    
 ?>
 
 <div class="content events__container events-single">
@@ -418,4 +425,27 @@
         <?php print __("Report Event", 'community-portal'); ?>
     </a>                                           
 </div>
+
 <?php endif ?>
+<?php if(in_array('administrator',  wp_get_current_user()->roles)): ?>
+<a href="#" id="events-show-debug-info" class="events-single__show-debug-info">Show Meta Data</a>
+<div class="events-single__debug-info events-single__debug-info--hidden">
+<h3>Debug Information</h3>
+
+Discourse Group Information
+<pre>
+    <?php
+        $discourse_group_info = mozilla_get_discourse_info($EM_Event->post_id, 'event');
+        print_r($discourse_group_info);
+    ?>
+</pre>
+
+Event Meta
+<pre>
+    <?php 
+        print_r($event_meta); 
+    ?>
+</pre>
+
+</div>
+<?php endif; ?>

--- a/plugins/events-manager/templates/template-parts/single-event-card.php
+++ b/plugins/events-manager/templates/template-parts/single-event-card.php
@@ -22,14 +22,13 @@
 
 
 ?> 
-
 <div class="col-lg-4 col-md-6 events__column">
     <div class="event-card">
         <a class="events__link" href="<?php echo $url?>">
             <div class="event-card__image"
             <?php 
-                $event_meta = get_post_meta($event->post_id, 'event-meta');
-                $img_url = $event_meta[0]->image_url;
+                $card_event_meta = get_post_meta($event->post_id, 'event-meta');
+                $img_url = $card_event_meta[0]->image_url;
 
                 if((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443) {
                     $img_url = preg_replace("/^http:/i", "https:", $img_url);
@@ -88,9 +87,9 @@
                     </p>
                 </div>
                 <?php endif; ?>
-                <?php if(isset($event_meta[0]->initiative) && strlen($event_meta[0]->initiative) > 0): ?>
+                <?php if(isset($card_event_meta[0]->initiative) && strlen($card_event_meta[0]->initiative) > 0): ?>
                 <?php
-                    $initiative = get_post(intval($event_meta[0]->initiative));
+                    $initiative = get_post(intval($card_event_meta[0]->initiative));
                 ?>
                 <div class="events__campaign">
                     <?php if($initiative->post_type === 'campaign'): ?>

--- a/scss/_event-single.scss
+++ b/scss/_event-single.scss
@@ -26,6 +26,23 @@
         }
     }
 
+    &__show-debug-info {
+        align-items: center;
+        color: $color-blue-50;
+        display: flex;
+        flex-direction: row;
+        font-size: remCalc(16);
+        line-height: 24px;
+        margin-top: 16px;
+        text-decoration: none; 
+    }
+
+    &__debug-info {
+        &.events-single__debug-info--hidden {
+            display: none;
+        }
+    }
+
     &__externam-link {
         color: $color-blue-50;
 

--- a/scss/_group.scss
+++ b/scss/_group.scss
@@ -873,4 +873,23 @@
         font-size: remCalc(14);
         line-height: 20px;
     }
+
+
+    &__show-debug-info {
+        align-items: center;
+        color: $color-blue-50;
+        display: flex;
+        flex-direction: row;
+        font-size: remCalc(16);
+        line-height: 24px;
+        margin-top: 16px;
+        text-decoration: none;  
+    }
+
+    &__debug-info {
+
+        &.group__debug-info--hidden {
+            display: none;
+        }
+    }
 }


### PR DESCRIPTION
Adds meta data code to the bottom of groups and events detail pages.  Must be an administrator of the site.  If you are an admin of the site there will be a link at the bottom of the page that allows you to show and hide meta data related to the post.  Test and make sure no administrators can see the link.