### PR TITLE
Refactored and added debug code

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -422,18 +422,30 @@ function mozilla_group_addional_column_info($retval = "", $column_name, $item) {
 
 function mozilla_save_post($post_id, $post, $update) {
 
-    if($post->post_type === 'event') {
+    if($post->post_type === 'event' && $update) {
 
         $user = wp_get_current_user();
-
+        $event_update_meta = get_post_meta($post->ID, 'event-meta');
         $event = new stdClass();
+
+        if(isset($event_update_meta[0]->discourse_group_id))
+            $event->discourse_group_id = $event_update_meta[0]->discourse_group_id;
+
+        if(isset($event_update_meta[0]->discourse_group_name))
+            $event->discourse_group_name = $event_update_meta[0]->discourse_group_name;
+
+        if(isset($event_update_meta[0]->discourse_group_description))
+            $event->discourse_group_description = $event_update_meta[0]->discourse_group_description;
+
+        if(isset($event_update_meta[0]->discourse_group_users))
+            $event->discourse_group_users = $event_update_meta[0]->discourse_group_users;
+
         $event->image_url = esc_url_raw($_POST['image_url']);
         $event->location_type = sanitize_text_field($_POST['location-type']);
         $event->external_url = esc_url_raw($_POST['event_external_link']);
 		$event->language = $_POST['language'] ? sanitize_text_field($_POST['language']) : '';
 		$event->goal = $_POST['goal'] ? sanitize_text_field($_POST['goal']): '';
 		$event->projected_attendees = $_POST['projected-attendees'] ? intval($_POST['projected-attendees']): '';
-
         
         if(isset($_POST['initiative_id']) && strlen($_POST['initiative_id']) > 0) {
             $initiative_id = intval($_POST['initiative_id']);
@@ -443,35 +455,25 @@ function mozilla_save_post($post_id, $post, $update) {
             }
         }
 
-        if($update) {
-            $discourse_api_data = Array();
-    
-            $discourse_api_data['name'] = $post->post_name;
-            $discourse_api_data['description'] = $post->post_content;
+        
+        $discourse_api_data = Array();
 
-            $event_meta = get_post_meta($post_id, 'event-meta');
-            if(!empty($event_meta) && isset($event_meta[0]->discourse_group_id)) {
-                $discourse_api_data['group_id'] = $event_meta[0]->discourse_group_id;
-                $discourse_event = mozilla_get_discourse_info($post_id, 'event');
-                $discourse_api_data['users'] = $discourse_event['discourse_group_users'];
-                $discourse_group = mozilla_discourse_api('groups', $discourse_api_data, 'patch');
-            } else {
-                $auth0Ids = Array();
-                $auth0Ids[] = mozilla_get_user_auth0($user->ID);
-                $discourse_api_data['users'] = $auth0Ids;
-                $discourse_group = mozilla_discourse_api('groups', $discourse_api_data, 'post');
-            }
-
-            if($discourse_group) {
-                if(isset($discourse_group->id)) {
-                    $event->discourse_group_id = $discourse_group->id;
-                } else {
-                    $event->discourse_log = $discourse_group;
-                }
-            }
-    
-            update_post_meta($post_id, 'event-meta', $event);
+        $discourse_api_data['name'] = $post->post_name;
+        $discourse_api_data['description'] = $post->post_content;
+        
+        if(!empty($event_update_meta) && isset($event_update_meta[0]->discourse_group_id)) {
+            $discourse_api_data['group_id'] = $event_update_meta[0]->discourse_group_id;
+            $discourse_event = mozilla_get_discourse_info($post_id, 'event');
+            $discourse_api_data['users'] = $discourse_event['discourse_group_users'];
+            $discourse_group = mozilla_discourse_api('groups', $discourse_api_data, 'patch');
         }
+
+        if($discourse_group) {
+            $event->discourse_log = $discourse_group;
+        }
+
+        update_post_meta($post->ID, 'event-meta', $event);
+    
 
     }
 }
@@ -520,10 +522,9 @@ function mozilla_post_status_transition($new_status, $old_status, $post) {
             mozilla_create_mailchimp_list($post);
         }    
 
-        if($post->post_type === 'event') {
+        if($post->post_type === 'event' && $old_status !== 'publish') {
 
             $user = wp_get_current_user();
-
             $event = new stdClass();
             $event->image_url = esc_url_raw($_POST['image_url']);
             $event->location_type = sanitize_text_field($_POST['location-type']);

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -443,31 +443,36 @@ function mozilla_save_post($post_id, $post, $update) {
             }
         }
 
-        $discourse_api_data = Array();
-
-        $discourse_api_data['name'] = $post->post_name;
-        $discourse_api_data['description'] = $post->post_content;
-        
         if($update) {
+            $discourse_api_data = Array();
+    
+            $discourse_api_data['name'] = $post->post_name;
+            $discourse_api_data['description'] = $post->post_content;
+
             $event_meta = get_post_meta($post_id, 'event-meta');
             if(!empty($event_meta) && isset($event_meta[0]->discourse_group_id)) {
                 $discourse_api_data['group_id'] = $event_meta[0]->discourse_group_id;
                 $discourse_event = mozilla_get_discourse_info($post_id, 'event');
                 $discourse_api_data['users'] = $discourse_event['discourse_group_users'];
                 $discourse_group = mozilla_discourse_api('groups', $discourse_api_data, 'patch');
+            } else {
+                $auth0Ids = Array();
+                $auth0Ids[] = mozilla_get_user_auth0($user->ID);
+                $discourse_api_data['users'] = $auth0Ids;
+                $discourse_group = mozilla_discourse_api('groups', $discourse_api_data, 'post');
             }
-        } else {
-            $auth0Ids = Array();
-            $auth0Ids[] = mozilla_get_user_auth0($user->ID);
-            $discourse_api_data['users'] = $auth0Ids;
-            $discourse_group = mozilla_discourse_api('groups', $discourse_api_data, 'post');
+
+            if($discourse_group) {
+                if(isset($discourse_group->id)) {
+                    $event->discourse_group_id = $discourse_group->id;
+                } else {
+                    $event->discourse_log = $discourse_group;
+                }
+            }
+    
+            update_post_meta($post_id, 'event-meta', $event);
         }
 
-        if($discourse_group) {
-            $event->discourse_group_id = $discourse_group->id;
-        }
-
-        update_post_meta($post_id, 'event-meta', $event);
     }
 }
 
@@ -514,6 +519,47 @@ function mozilla_post_status_transition($new_status, $old_status, $post) {
         if($post->post_type === 'campaign') {            
             mozilla_create_mailchimp_list($post);
         }    
+
+        if($post->post_type === 'event') {
+
+            $user = wp_get_current_user();
+
+            $event = new stdClass();
+            $event->image_url = esc_url_raw($_POST['image_url']);
+            $event->location_type = sanitize_text_field($_POST['location-type']);
+            $event->external_url = esc_url_raw($_POST['event_external_link']);
+            $event->language = $_POST['language'] ? sanitize_text_field($_POST['language']) : '';
+            $event->goal = $_POST['goal'] ? sanitize_text_field($_POST['goal']): '';
+            $event->projected_attendees = $_POST['projected-attendees'] ? intval($_POST['projected-attendees']): '';
+
+            if(isset($_POST['initiative_id']) && strlen($_POST['initiative_id']) > 0) {
+                $initiative_id = intval($_POST['initiative_id']);
+                $initiative = get_post($initiative_id);
+                if($initiative && ($initiative->post_type === 'campaign' || $initiative->post_type === 'activity')) {
+                    $event->initiative = $initiative_id;
+                }
+            }
+
+            $discourse_api_data = Array();
+            $discourse_api_data['name'] = $post->post_name;
+            $discourse_api_data['description'] = $post->post_content;
+            $auth0Ids = Array();
+            $auth0Ids[] = mozilla_get_user_auth0($user->ID);
+            $discourse_api_data['users'] = $auth0Ids;
+            $discourse_group = mozilla_discourse_api('groups', $discourse_api_data, 'post');
+
+            if($discourse_group) {
+                if(isset($discourse_group->id)) {
+                    $event->discourse_group_id = $discourse_group->id;
+                } else {
+                    $event->discourse_log = $discourse_group;
+                }
+            }
+
+            update_post_meta($post->ID, 'event-meta', $event);
+
+        }
+
     } 
 } 
 


### PR DESCRIPTION
I refactored how the event create and update hooks handle meta data and added some new logging to help debug the issue happening to discourse and events.  

Check that event creation for all fields still works and updating all fields still work.

As an admin check if all fields are being populated and a discourse group is being updated / created.  If you need the discourse theme setting information let me know and I can send it to you.

You can check the event meta data at the bottom of the page as a site administrator.  After an event is created if you are an admin it should have 2 arrays one with discourse information and the other with standard meta information.
