### PR TITLE
added admin functions to update event discourse data

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -62,7 +62,8 @@ add_action('wp_ajax_export_users', 'mozilla_export_users');
 add_action('wp_ajax_update_group_discourse', 'mozilla_update_group_discourse_category_id');
 add_action('wp_ajax_nopriv_export_events', 'mozilla_event_export');
 add_action('wp_ajax_export_events', 'mozilla_event_export');
-
+add_action('wp_ajax_update_event_discourse', 'mozilla_update_event_discourse_data');
+add_action('wp_ajax_add_user_to_discourse_group', 'mozilla_add_user_discourse');
 
 add_action('wp_ajax_download_group_events', 'mozilla_download_group_events');
 

--- a/lib/events.php
+++ b/lib/events.php
@@ -196,7 +196,53 @@ function mozilla_event_export() {
     fclose($out);
 
     die();
+}
 
+function mozilla_update_event_discourse_data() {
+
+    if(!is_admin() && in_array('administrator', wp_get_current_user()->roles)) {
+        return;
+    }
+
+    if(isset($_GET['event'])) {
+        $event = new EM_Event(intval($_GET['event']), 'post_id');
+        $event_meta = get_post_meta(intval($_GET['event']), 'event-meta');
+
+        if(isset($_GET['discourse_group_id'])) {
+            $event_meta[0]->discourse_group_id = intval($_GET['discourse_group_id']);
+        }
+
+        update_post_meta(intval($_GET['event']), 'event-meta', $event_meta[0]);
+    }
+
+    die();
+}
+
+function mozilla_add_user_discourse() {
+
+    if(!is_admin() && in_array('administrator', wp_get_current_user()->roles)) {
+        return;
+    }
+
+    if(isset($_GET['event']) && isset($_GET['user'])) {
+        $event = new EM_Event(intval($_GET['event']), 'post_id');
+        $discourse_group_info = mozilla_get_discourse_info($_GET['event'], 'event');
+
+        $discourse_api_data = Array();
+        $discourse_api_data['group_id'] = $discourse_group_info['discourse_group_id'];
+        $user = get_user_by('slug', trim($_GET['user']));
+
+        if($user) {
+            $add = Array();
+            $add[] = mozilla_get_user_auth0($user->ID);
+            $discourse_api_data['add_users'] = $add;
+    
+            $discourse = mozilla_discourse_api('groups/users', $discourse_api_data, 'patch');
+        }
+    }
+
+
+    die();
 
 }
 

--- a/plugins/events-manager/templates/event-single.php
+++ b/plugins/events-manager/templates/event-single.php
@@ -30,10 +30,6 @@
 	$language = isset($event_meta[0]->language) && strlen($event_meta[0]->language) > 0 ? $languages[$event_meta[0]->language] : false;
 	$projected_attendees = isset($event_meta[0]->projected_attendees) && intval($event_meta[0]->projected_attendees) > 0 ? $event_meta[0]->projected_attendees : false;
 
-
-    
-
-
     $months = array(
         '01' => 'January',
         '02' => 'February',


### PR DESCRIPTION
This PR allows admins to update event discourse group id manually and add a user by username manually.  Make sure you are using the Event's post_id not it's regular ID.  Event manager uses 2 IDS one is the native Wordpress id found under post_id and  a regular ID for event manager to reference from.

/wp-admin/admin-ajax.php?action=add_user_to_discourse_group&user=<USERNAME>&event=<EVENT_POST_ID>

/admin-ajax.php?action=update_event_discourse&event=<EVENT_POST_ID>&discourse_group_id=<DISCOURSE_GROUP_ID>