### PR TITLE
Hide emails when not logged in

### DIFF
--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -1501,7 +1501,7 @@
                     </div>
                     <?php endif; ?>
                 </section>
-                <?php if(isset($options['report_email'])): ?>
+                <?php if(isset($options['report_email']) && is_user_logged_in()): ?>
                 <div class="group__report-container">
                     <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Group', 'community-portal'), $group->name); ?>&body=<?php print __(sprintf('Please provide a reason you are reporting this group    %s', "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}"), 'community-portal'); ?>" class="group__report-group-link">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/plugins/events-manager/templates/event-single.php
+++ b/plugins/events-manager/templates/event-single.php
@@ -410,7 +410,7 @@
         <?php include(locate_template('templates/share-modal.php', false, false)); ?>
     </div>
 </div>
-<?php if(isset($options['report_email'])): ?>
+<?php if(isset($options['report_email']) && is_user_logged_in()): ?>
 <div class="events-single__report-container">
     <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Event', 'community-portal'), $group->name); ?>&body=<?php print sprintf('%s %s', __('Please provide a reason you are reporting this event', 'community-portal'), "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}"); ?>" class="events-single__report-group-link">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
This PR hides the report emails when a user is not logged in.  stops bots from crawling site unless they have a login.