### PR TITLE
Updated gettext functions

### DIFF
--- a/buddypress/groups/index-create.php
+++ b/buddypress/groups/index-create.php
@@ -37,20 +37,20 @@
         <?php if($step != 3): ?>
         <div class="create-group__hero">
             <div class="create-group__hero-container">
-                <h1 class="create-group__title"><?php print __("Create a Mozilla Group", "community-portal"); ?></h1>
+                <h1 class="create-group__title"><?php _e('Create a Mozilla Group', 'community-portal'); ?></h1>
             </div>
         </div>
         <form action="<?php bp_group_creation_form_action(); ?>" method="post" id="create-group-form" class="standard-form create-group__form" enctype="multipart/form-data" novalidate>
             <div class="create-group__container">
                 <ol class="create-group__menu">
-                    <li class="create-group__menu-item<?php if($step == 1): ?> create-group__menu-item--disabled<?php endif;?>"><a href="#" class="create-group__menu-link<?php if($step == 1): ?> create-group__menu-link--disabled<?php endif; ?>" data-step=""><?php print __("Basic Information", "community-portal"); ?></a></li>
-                    <li class="create-group__menu-item<?php if($step != 1): ?> create-group__menu-item--disabled<?php endif;?>"><a href="#" class="create-group__menu-link<?php if($step != 1): ?> create-group__menu-link--disabled<?php endif; ?>" data-step=""><?php print __("Terms & Responsibilities", "community-portal"); ?></a></li>
+                    <li class="create-group__menu-item<?php if($step == 1): ?> create-group__menu-item--disabled<?php endif;?>"><a href="#" class="create-group__menu-link<?php if($step == 1): ?> create-group__menu-link--disabled<?php endif; ?>" data-step=""><?php _e('Basic Information', 'community-portal'); ?></a></li>
+                    <li class="create-group__menu-item<?php if($step != 1): ?> create-group__menu-item--disabled<?php endif;?>"><a href="#" class="create-group__menu-link<?php if($step != 1): ?> create-group__menu-link--disabled<?php endif; ?>" data-step=""><?php _e('Terms & Responsibilities', 'community-portal'); ?></a></li>
                 </ol>
                 <div class="create-group__menu create-group__menu--mobile">
                     <div class="create-group__select-container">
                         <select id="create-group-mobile-nav" class="create-group__select" name="mobile_nav">
-                            <option value="1"<?php if($step != 1): ?> selected<?php endif; ?>><?php print __("Basic Information", "community-portal"); ?></option>
-                            <option value="2"<?php if($step == 1): ?> selected<?php endif; ?>><?php print __("Terms & Responsibilities", "community-portal"); ?></option>
+                            <option value="1"<?php if($step != 1): ?> selected<?php endif; ?>><?php  _e('Basic Information', 'community-portal'); ?></option>
+                            <option value="2"<?php if($step == 1): ?> selected<?php endif; ?>><?php _e('Terms & Responsibilities', 'community-portal'); ?></option>
                         </select>
                     </div>
                 </div>
@@ -62,28 +62,28 @@
                     <section class="create-group__details<?php if($step == 1): ?> create-group__details--hidden<?php endif; ?>">
                         <div class="create-group__input-row">
                             <div class="create-group__input-container create-group__input-container--60">
-                                <label class="create-group__label" for="group-name"><?php print __("What is your group's name? *", "community-portal"); ?></label>
+                                <label class="create-group__label" for="group-name"><?php _e('What is your group\'s name? *', 'community-portal'); ?></label>
                                 <input type="text" name="group_name" id="group-name" class="create-group__input<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($form['group_name']) || (isset($form['group_name']) && empty(trim($form['group_name'])) )): ?> create-group__input--error<?php endif; ?>" value="<?php print isset($form['group_name']) ? $form['group_name'] : ''; ?>" required />
                                 <div class="form__error-container<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($form['group_name']) || (isset($form['group_name']) && empty(trim($form['group_name'])) )): ?> form__error-container--visible<?php endif; ?>">
-                                    <div class="form__error"><?php print __("This field is required", "community-portal"); ?></div>
+                                    <div class="form__error"><?php _e('This field is required', 'community-portal'); ?></div>
                                 </div>
                             </div>
                             <div class="create-group__input-container create-group__input-container--40">
-                                <label class="create-group__label" for="group-type"><?php print __("Group Type", "community-portal"); ?></label>
+                                <label class="create-group__label" for="group-type"><?php _e('Group Type', 'community-portal'); ?></label>
                                 <div class="create-group__select-container">
                                     <select id="group-type" class="create-group__select" name="group_type" required>
-                                        <option value="Online"<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($form['group_type']) && $form['group_type'] == 'Online' || (empty($form['group_type']))): ?> selected<?php endif; ?>><?php print __("Online", "community-portal"); ?></option>
-                                        <option value="Offline"<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($form['group_type']) && $form['group_type'] == 'Offline'): ?> selected<?php endif; ?>><?php print __("Offline", "community-portal"); ?></option>
+                                        <option value="Online"<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($form['group_type']) && $form['group_type'] == 'Online' || (empty($form['group_type']))): ?> selected<?php endif; ?>><?php _e('Online', 'community-portal'); ?></option>
+                                        <option value="Offline"<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($form['group_type']) && $form['group_type'] == 'Offline'): ?> selected<?php endif; ?>><?php _e('Offline', 'community-portal'); ?></option>
                                     </select>
                                 </div>
 							</div>
                         </div>
                         <div class="create-group__input-row">
                             <div class="create-group__input-container create-group__input-container--full create-group__input-container--vertical-spacing">
-                                <label class="create-group__label" for="group-language"><?php print __("Language", "community-portal"); ?></label>
+                                <label class="create-group__label" for="group-language"><?php _e('Language', 'community-portal'); ?></label>
                                 <div class="create-group__select-container">
                                     <select id="group-language" class="create-group__select" name="group_language">
-                                        <option value="0"><?php print __("Language", "community-portal"); ?></option>
+                                        <option value="0"><?php _e('Language', 'community-portal'); ?></option>
                                         <?php foreach($languages AS $code =>  $language_name): ?>
                                         <option value="<?php print $code; ?>"<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($form['group_language']) && $form['group_language'] == $code): ?> selected<?php endif; ?>><?php print $language_name; ?></option>
                                         <?php endforeach; ?>
@@ -93,31 +93,31 @@
                         </div>
                         <div class="create-group__input-row">
                             <div class="create-group__input-container  create-group__input-container--40 create-group__input-container--vertical-spacing">
-                                <label class="create-group__label" for="group-country"><?php print __("Group Location", "community-portal"); ?></label>
+                                <label class="create-group__label" for="group-country"><?php _e('Group Location', 'community-portal'); ?></label>
                                 <div class="create-group__select-container">
                                     <select id="group-country" class="create-group__select" name="group_country">
-                                        <option value="0"><?php print __("Country", "community-portal"); ?></option>
+                                        <option value="0"><?php _e('Country', 'community-portal'); ?></option>
                                         <?php foreach($countries AS $code => $country): ?>
-                                        <option value="<?php print $code; ?>"<?php if(isset($form['group_country']) && $form['group_country'] === $code): ?> selected<?php endif; ?>><?php print __($country); ?></option>
+                                        <option value="<?php print $code; ?>"<?php if(isset($form['group_country']) && $form['group_country'] === $code): ?> selected<?php endif; ?>><?php print $country; ?></option>
                                         <?php endforeach; ?>
                                     </select>
                                 </div>
                             </div>
                             <div class="create-group__input-container create-group__input-container--60 create-group__input-container--vertical-spacing">
-                                <label class="create-group__label" for="group-city"><?php print __("City", "community-portal"); ?></label>
-                                <input type="text" name="group_city" id="group-city" class="create-group__input" placeholder="<?php print __("City", "community-portal"); ?>" value="<?php print isset($form['group_city']) ? $form['group_city'] : ''; ?>" maxlength="180" />
+                                <label class="create-group__label" for="group-city"><?php _e('City', 'community-portal'); ?></label>
+                                <input type="text" name="group_city" id="group-city" class="create-group__input" placeholder="<?php _e('City', 'community-portal'); ?>" value="<?php print isset($form['group_city']) ? $form['group_city'] : ''; ?>" maxlength="180" />
                             </div>
                         </div>
                         <div class="create-group__input-row">
                             <div class="create-group__input-container create-group__input-container--60 create-group__input-container--vertical-spacing">
-                                <label class="create-group__label" for="group-desc"><?php print __("Provide a short group description *", "community-portal"); ?></label>
+                                <label class="create-group__label" for="group-desc"><?php _e('Provide a short group description *', 'community-portal'); ?></label>
                                 <textarea name="group_desc" id="group-desc" class="create-group__textarea<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($form['group_desc']) || (isset($form['group_desc']) && empty(trim($form['group_desc'])) )): ?> create-group__input--error<?php endif; ?>" required maxlength="3000"><?php print isset($form['group_desc']) ? $form['group_desc'] : ''; ?></textarea>
                                 <div class="form__error-container<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($form['group_desc']) || (isset($form['group_desc']) && empty(trim($form['group_desc'])) )): ?> form__error-container--visible<?php endif; ?>">
-                                    <div class="form__error"><?php print __("This field is required", "community-portal"); ?></div>
+                                    <div class="form__error"><?php _e('This field is required', 'community-portal'); ?></div>
                                 </div>
                             </div>
                             <div class="create-group__input-container create-group__input-container--40 create-group__input-container--vertical-spacing">
-                                <label class="create-group__label"><?php print __("Select an image", "community-portal"); ?></label>
+                                <label class="create-group__label"><?php _e('Select an image', 'community-portal'); ?></label>
                                 <div id="dropzone-photo-uploader" class="create-group__image-upload">
 									<div class="dz-message" data-dz-message="">
 										<div>
@@ -125,11 +125,11 @@
 												<div class="form__error form__error--image"></div>
 											</div>
 											<button type="button" id="dropzone-trigger" class="dropzone__image-instructions create-group__image-instructions">
-												<?php print __("Click or drag a photo above", "community-portal"); ?>
-												<span><?php print __('min dimensions 703px by 400px', "community-portal"); ?></span>
+												<?php _e('Click or drag a photo above', 'community-portal'); ?>
+												<span><?php _e('min dimensions 703px by 400px', 'community-portal'); ?></span>
 											</button>
 										</div>
-										<button type="button" class="dz-remove<?php if(!isset($form['image_url']) || strlen($form['image_url']) === 0): ?> dz-remove--hide<?php endif; ?>" data-dz-remove="" >Remove file</button>
+										<button type="button" class="dz-remove<?php if(!isset($form['image_url']) || strlen($form['image_url']) === 0): ?> dz-remove--hide<?php endif; ?>" data-dz-remove="" ><?php _e('Remove file', 'community-portal'); ?></button>
 									</div>
                                 </div>
                                 <input type="hidden" name="image_url" id="image-url" value="<?php print (isset($form['image_url'])) ? $form['image_url'] : '' ?>" />
@@ -138,7 +138,7 @@
                         <div class="create-group__input-row">
                             <div class="create-group__input-container create-group__input-container--full create-group__input-container--vertical-spacing">
 								<fieldset class="fieldset">
-									<legend class="create-group__label"><?php print __("Tags for your group", "community-portal"); ?></legend>
+									<legend class="create-group__label"><?php _e('Tags for your group', 'community-portal'); ?></legend>
 									<?php 
 										// Get all tags
 										$tags = get_tags(array('hide_empty' => false));
@@ -155,75 +155,75 @@
                         </div>
                     </section>
                     <section class="create-group__details<?php if($step == 1): ?> create-group__details--hidden<?php endif; ?>">
-                        <div class="create-group__section-title"><?php print __("Group Meetings", "community-portal"); ?></div>
+                        <div class="create-group__section-title"><?php _e('Group Meetings', 'community-portal'); ?></div>
                         <div class="create-group__input-row">
                             <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--40">    
-                                <label class="create-group__label" for="group-address-type" ><?php print __("Where do you meet?", "community-portal"); ?></label>
+                                <label class="create-group__label" for="group-address-type" ><?php _e('Where do you meet?', 'community-portal'); ?></label>
                                 <div class="create-group__select-container">
                                     <select class="create-group__select" name="group_address_type" id="group-address-type">
-                                        <option value="<?php print __("Address", "community-portal"); ?>" <?php if(isset($form['group_address_type']) && $form['group_address_type'] == 'Address'):?> selected<?php endif;?>><?php print __("Address", "community-portal"); ?></option>
-                                        <option value="<?php print __("URL", "community-portal"); ?>"<?php if(isset($form['group_address_type']) && $form['group_address_type'] == 'URL'):?> selected<?php endif;?>><?php print __("URL", "community-portal"); ?></option>
+                                        <option value="<?php _e('Address', 'community-portal'); ?>" <?php if(isset($form['group_address_type']) && $form['group_address_type'] == 'Address'):?> selected<?php endif;?>><?php _e('Address', 'community-portal'); ?></option>
+                                        <option value="<?php _e('URL', 'community-portal'); ?>"<?php if(isset($form['group_address_type']) && $form['group_address_type'] == 'URL'):?> selected<?php endif;?>><?php _e('URL', 'community-portal'); ?></option>
                                     </select>
                                 </div>
                             </div>
                             <div class="create-group__input-container create-group__input-container--60 create-group__input-container--vertical-spacing">
-                                <label class="create-group__label" for="group-address" ><?php print __("Address", "community-portal"); ?></label>
+                                <label class="create-group__label" for="group-address" ><?php _e('Address', 'community-portal'); ?></label>
                                 <input type="text" name="group_address" id="group-address" class="create-group__input" value="<?php print isset($form['group_address']) ? $form['group_address'] : ''; ?>" />
                             </div>
                         </div>
                         <div class="create-group__input-container create-group__input-container--full">
-                            <label class="create-group__label" for="group-desc"><?php print __("Meeting details", "community-portal"); ?></label>
+                            <label class="create-group__label" for="group-desc"><?php _e('Meeting details', 'community-portal'); ?></label>
                             <textarea name="group_meeting_details" id="group-meeting-details" class="create-group__textarea create-group__textarea--full create-group__textarea--short" ><?php print isset($form['group_meeting_details']) ? $form['group_meeting_details'] : ''; ?></textarea>
                         </div>
                     </section>
                     <section class="create-group__details<?php if($step == 1): ?> create-group__details--hidden<?php endif; ?>">
-						<h2 class="create-group__section-title"><?php print __("Community Links", "community-portal"); ?></h2>
+						<h2 class="create-group__section-title"><?php _e('Community Links', 'community-portal'); ?></h2>
                         <div class="create-group__input-row create-group__subsection">
                             <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-								<label class="create-group__label" for="group-discourse"><?php print __("Discourse", "community-portal"); ?></label>
+								<label class="create-group__label" for="group-discourse"><?php _e('Discourse', 'community-portal'); ?></label>
 								<input type="text" name="group_discourse" id="group-discourse" placeholder="https://" class="create-group__input create-group__input--inline create-group__community-link" value="<?php print isset($form['group_discourse']) ? $form['group_discourse'] : ''; ?>" />
                             </div>
 							<div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-								<label class="create-group__label"  for="group-matrix"><?php print __("Matrix", "community-portal"); ?></label>
+								<label class="create-group__label"  for="group-matrix"><?php _e('Matrix', 'community-portal'); ?></label>
 								<input type="text" placeholder="room-alias:domain" name="group_matrix" id="group-matrix" class="create-group__input 	create-group__input--inline"  value="<?php print isset($form['group_matrix']) ? $form['group_matrix'] : ''; ?>"/>
 								<div class="form__error-container form__error-container--checkbox">
-									<div class="form__error"><?php print __("Please format as room-alias:domain", "community-portal"); ?></div>
+									<div class="form__error"><?php _e('Please format as room-alias:domain', 'community-portal'); ?></div>
 								</div>
 							</div>
                         </div>
                         <div class="create-group__input-row">
                             <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-								<label class="create-group__label" for="group-facebook"><?php print __("Facebook", "community-portal"); ?></label>
+								<label class="create-group__label" for="group-facebook"><?php _e('Facebook', 'community-portal'); ?></label>
 								<input type="text" name="group_facebook" id="group-facebook" placeholder="https://" class="create-group__input create-group__input--inline create-group__community-link"  value="<?php print isset($form['group_facebook']) ? $form['group_facebook'] : ''; ?>"/>
                             </div>
                             <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-								<label class="create-group__label" for="group-twitter"><?php print __("Twitter", "community-portal"); ?></label>
+								<label class="create-group__label" for="group-twitter"><?php _e('Twitter', 'community-portal'); ?></label>
 								<input type="text" name="group_twitter" id="group-twitter" placeholder="https://" class="create-group__input create-group__input--inline create-group__community-link"  value="<?php print isset($form['group_twitter']) ? $form['group_twitter'] : ''; ?>"/>
                             </div>
                         </div>
 						<div class="create-group__input-row">
 							<div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-							<label class="create-group__label" for="group-telegram"><?php print __("Telegram", "community-portal"); ?></label>
+							<label class="create-group__label" for="group-telegram"><?php _e('Telegram', 'community-portal'); ?></label>
 							<input type="text" placeholder="https://" name="group_telegram" id="group-telegram" class="create-group__input create-group__input--inline"  value="<?php print isset($form['group_telegram']) ? $form['group_telegram'] : ''; ?>"/>
 						</div>
 						<div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-							<label class="create-group__label" for="group-github"><?php print __("GitHub", "community-portal"); ?></label>
+							<label class="create-group__label" for="group-github"><?php _e('GitHub', 'community-portal'); ?></label>
 							<input type="text" name="group_github" id="group-github" placeholder="https://" class="create-group__input create-group__input--inline create-group__community-link"  value="<?php print isset($form['group_github']) ? $form['group_github'] : ''; ?>"/>
 						</div>
 
 					</div>
 					<div class="create-group__input-row">
 						<div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-							<label class="create-group__label"  for="group-other"><?php print __("Other", "community-portal"); ?></label>
+							<label class="create-group__label"  for="group-other"><?php _e('Other', 'community-portal'); ?></label>
 							<input type="text" placeholder="https://" name="group_other" id="group-other" class="create-group__input create-group__input--inline"  value="<?php print isset($form['group_other']) ? $form['group_other'] : ''; ?>"/>
 						</div>
 					</div>
                     </section>
                     <section class="create-group__details<?php if($step == 1): ?> create-group__details--hidden<?php endif; ?>">
                         <div class="create-group__section-title">
-                            <?php print __("Secondary Group Contact", "community-portal"); ?>
+                            <?php _e('Secondary Group Contact', 'community-portal'); ?>
                             <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <title><?php print __("Secondary group contact", "community-portal"); ?></title>
+                                <title><?php _e('Secondary group contact', 'community-portal'); ?></title>
                                 <path d="M9 16.5C13.1421 16.5 16.5 13.1421 16.5 9C16.5 4.85786 13.1421 1.5 9 1.5C4.85786 1.5 1.5 4.85786 1.5 9C1.5 13.1421 4.85786 16.5 9 16.5Z" stroke="#CDCDD4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 <path d="M9 6V9" stroke="#CDCDD4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                 <circle cx="9" cy="12" r="0.75" fill="#CDCDD4"/>
@@ -232,10 +232,10 @@
                         </div>
                         <div class="create-group__input-row">
                             <div class="create-group__input-container create-group__input-container--full">
-                                <label for="group-admin" class="create-group__label"><?php print __("Username *", "community-portal"); ?></label>
-                                <input type="text" name="group_admin" id="group-admin" class="create-group__input" value="<?php print isset($form['group_admin']) ? $form['group_admin'] : ''; ?>" placeholder="Username" required/>
+                                <label for="group-admin" class="create-group__label"><?php _e('Username *', 'community-portal'); ?></label>
+                                <input type="text" name="group_admin" id="group-admin" class="create-group__input" value="<?php print isset($form['group_admin']) ? $form['group_admin'] : ''; ?>" placeholder="<?php _e('Username', 'community-portal'); ?>" required/>
                                 <div class="form__error-container<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($form['group_admin_id']) || (isset($form['group_admin_id']) && empty(trim($form['group_admin_id'])) )): ?> form__error-container--visible<?php endif; ?>">
-                                    <div class="form__error"><?php print __("This field is required", "community-portal"); ?></div>
+                                    <div class="form__error"><?php _e('This field is required', 'community-portal'); ?></div>
                                 </div>
                                 <input type="hidden" name="group_admin_id" id="group-admin-id" value="<?php print isset($form['group_admin_id']) ? $form['group_admin_id'] : ''; ?>" required/>
                             </div>
@@ -244,7 +244,7 @@
                     <?php if($step == 1): ?>
                     <section class="create-group__details">
                         <?php
-                            $category_id = get_cat_ID('Group Terms of Service', "community-portal");
+                            $category_id = get_cat_ID('Group Terms of Service', 'community-portal');
                             $terms_of_service_posts = get_posts(Array(
                                 'numberposts'   =>  1,
                                 'category'      =>  $category_id
@@ -256,12 +256,12 @@
                             <?php print apply_filters('the_content', $terms_of_service_posts[0]->post_content); ?> 
                         </div>
                         <div class="create-group__input-container create-group__input-container--full cpg">
-							<input class="checkbox--hidden" type="checkbox" name="agree" id="agree" value="<?php print __("I Agree", "community-portal"); ?>" required />
+							<input class="checkbox--hidden" type="checkbox" name="agree" id="agree" value="<?php _e('I Agree', 'community-portal'); ?>" required />
                             <label class="cpg__label" for="agree">
-								<?php print __("I agree to respect and adhere to", "community-portal"); ?>
-								<a class="create-group__checkbox-container__link" href="https://www.mozilla.org/en-US/about/governance/policies/participation/"><?php print __("Mozilla’s Community Participation Guidelines *", "community-portal") ?></a>
+								<?php _e('I agree to respect and adhere to', 'community-portal'); ?>
+								<a class="create-group__checkbox-container__link" href="https://www.mozilla.org/en-US/about/governance/policies/participation/"><?php _e('Mozilla’s Community Participation Guidelines *', 'community-portal') ?></a>
                                 <div class="form__error-container form__error-container--checkbox">
-                                    <div class="form__error"><?php print __("This field is required", "community-portal"); ?></div>
+                                    <div class="form__error"><?php _e('This field is required', 'community-portal'); ?></div>
                                 </div>
                             </label>
                         </div>
@@ -270,7 +270,7 @@
                     </section>
                     <?php endif; ?>
                     <section class="create-group__cta-container">
-                        <input type="submit" class="create-group__cta" value="<?php print __("Continue", "community-portal"); ?>" />
+                        <input type="submit" class="create-group__cta" value="<?php _e('Continue', 'community-portal'); ?>" />
                     </section>
                 
                 <?php endif; ?>      

--- a/buddypress/groups/index-directory.php
+++ b/buddypress/groups/index-directory.php
@@ -219,12 +219,12 @@
     <div class="groups">
         <div class="groups__hero">
             <div class="groups__hero-container">
-                <h1 class="groups__title"><?php print __("Groups", "community-portal"); ?></h1>
+                <h1 class="groups__title"><?php _e('Groups', 'community-portal'); ?></h1>
                 <p class="groups__hero-copy">
-                    <?php print __("Meet up with people who share your passion and join the movement for an open internet.", "community-portal"); ?>
+                    <?php _e('Meet up with people who share your passion and join the movement for an open internet.', 'community-portal'); ?>
                 </p>
                 <p class="groups__hero-copy">
-                    <?php print __("Look for groups in your area, or", "community-portal"); ?> <a href="/groups/create/step/group-details/" class="groups__hero-link"><?php print __('create your own.', "community-portal"); ?></a>
+                    <?php _e('Look for groups in your area, or', 'community-portal'); ?> <a href="/groups/create/step/group-details/" class="groups__hero-link"><?php _e('create your own.', 'community-portal'); ?></a>
                     <svg width="8" height="10" viewBox="0 0 8 10" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M2.33337 8.66634L6.00004 4.99967L2.33337 1.33301" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                     </svg>
@@ -241,9 +241,9 @@
                             <path d="M17.5 17.5L13.875 13.875" stroke="#737373" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                         </svg>
 
-                        <input type="text" name="q" id="groups-search" class="groups__search-input" placeholder="<?php print __("Search groups", "community-portal"); ?>" value="<?php if(isset($original_query)): ?><?php print $original_query; ?><?php endif; ?>" />
+                        <input type="text" name="q" id="groups-search" class="groups__search-input" placeholder="<?php _e('Search groups', 'community-portal'); ?>" value="<?php if(isset($original_query)): ?><?php print $original_query; ?><?php endif; ?>" />
                         </div>
-                        <input type="button" class="groups__search-cta" value="<?php print __("Search", "community-portal"); ?>" />
+                        <input type="button" class="groups__search-cta" value="<?php _e('Search', 'community-portal'); ?>" />
                     </form>
                 </div>
             </div>
@@ -252,23 +252,23 @@
         <div class="groups__container">
             <div class="groups__nav">
                 <ul class="groups__menu">
-                    <li class="menu-item"><a class="groups__menu-link<?php if(!isset($_GET['mygroups']) || (isset($_GET['mygroups']) && $_GET['mygroups'] == 'false')): ?> group__menu-link--active<?php endif; ?>" href="#" data-nav=""><?php print __("Discover Groups", "community-portal"); ?></a></li>
-                    <?php if($logged_in): ?><li class="menu-item"><a class="groups__menu-link<?php if(isset($_GET['mygroups']) && $_GET['mygroups'] == 'true'): ?> group__menu-link--active<?php endif; ?>" href="#" data-nav="mygroups"><?php print __("Groups I'm In", "community-portal"); ?></a></li><?php endif; ?>
+                    <li class="menu-item"><a class="groups__menu-link<?php if(!isset($_GET['mygroups']) || (isset($_GET['mygroups']) && $_GET['mygroups'] == 'false')): ?> group__menu-link--active<?php endif; ?>" href="#" data-nav=""><?php _e('Discover Groups', 'community-portal'); ?></a></li>
+                    <?php if($logged_in): ?><li class="menu-item"><a class="groups__menu-link<?php if(isset($_GET['mygroups']) && $_GET['mygroups'] == 'true'): ?> group__menu-link--active<?php endif; ?>" href="#" data-nav="mygroups"><?php _e('Groups I\'m In', 'community-portal'); ?></a></li><?php endif; ?>
                 </ul>
             </div>
             <div class="groups__nav groups__nav--mobile">
-                <?php print __("Showing", "community-portal"); ?>
+                <?php _e('Showing', 'community-portal'); ?>
                 <select class="groups__nav-select">
-                    <option value="all"><?php print __("Discover Groups", "community-portal"); ?></option>
-                    <?php if($logged_in): ?><option value="mygroups"<?php if(isset($_GET['mygroups']) && $_GET['mygroups'] == 'true'): ?>selected<?php endif; ?>><?php print __("Groups I'm in", "community-portal"); ?></option><?php endif; ?>
+                    <option value="all"><?php _e('Discover Groups', 'community-portal'); ?></option>
+                    <?php if($logged_in): ?><option value="mygroups"<?php if(isset($_GET['mygroups']) && $_GET['mygroups'] == 'true'): ?>selected<?php endif; ?>><?php _e('Groups I\'m in', 'community-portal'); ?></option><?php endif; ?>
                 </select>            
             </div>
                 <div class="groups__filter-container<?php if(!isset($_GET['location']) && !isset($_GET['mygroups'])): ?> groups__filter-container--hidden<?php endif; ?>">
-                <span><?php print __("Filter by:", "community-portal"); ?></span>
+                <span><?php _e('Filter by:', 'community-portal'); ?></span>
                 <div class="groups__select-container">
-                    <label class="groups__label"><?php print __("Location", "community-portal"); ?></label>
+                    <label class="groups__label"><?php _e('Location', 'community-portal'); ?></label>
                     <select class="groups__location-select">
-                        <option value=""><?php print __('All', "community-portal"); ?></option>
+                        <option value=""><?php _e('All', 'community-portal'); ?></option>
                         <?php foreach($used_country_list AS $code   =>  $country): ?>
                         <option value="<?php print $code; ?>"<?php if(isset($_GET['location']) && strlen($_GET['location']) > 0 && $_GET['location'] == $code): ?> selected<?php endif; ?>><?php print $country; ?></option>
                         <?php endforeach; ?>
@@ -276,9 +276,9 @@
                 </div>
                 <?php if(sizeof($used_language_list) > 0): ?>
                 <div class="groups__select-container">
-                    <label class="groups__label"><?php print __("Language", "community-portal"); ?></label>
+                    <label class="groups__label"><?php _e('Language', 'community-portal'); ?></label>
                     <select class="groups__language-select">
-                        <option value=""><?php print __('All', "community-portal"); ?></option>
+                        <option value=""><?php _e('All', "community-portal"); ?></option>
                         <?php foreach($used_language_list AS $code   =>  $language): ?>
                         <?php if(strlen($code) > 1): ?>
                         <option value="<?php print $code; ?>"<?php if(isset($_GET['language']) && strlen($_GET['language']) > 0 && $_GET['language'] == $code): ?> selected<?php endif; ?>><?php print $language; ?></option>
@@ -288,9 +288,9 @@
                 </div>
                 <?php endif; ?>
                 <div class="groups__select-container">
-                    <label class="groups__label"><?php print __("Tag", "community-portal"); ?></label>
+                    <label class="groups__label"><?php _e('Tag', 'community-portal'); ?></label>
                     <select class="groups__tag-select">
-                        <option value=""><?php print __('All', "community-portal"); ?></option>
+                        <option value=""><?php _e('All', 'community-portal'); ?></option>
                         <?php foreach($tags AS $tag): ?>
                         <option value="<?php print $tag->slug; ?>" <?php if(isset($_GET['tag']) && strtolower(trim($_GET['tag'])) == strtolower($tag->slug)): ?> selected<?php endif; ?>><?php print $tag->name; ?></option>
                         <?php endforeach; ?>
@@ -298,16 +298,16 @@
                 </div>
             </div>
             <div class="groups__show-filters-container">
-                <a href="#" class="groups__show-filter"><?php if(isset($_GET['location']) || isset($_GET['mygroups'])): ?><?php print __("Hide Filters", "community-portal"); ?><?php else: ?><?php print __("Show Filters", "community-portal"); ?><?php endif; ?></a>
+                <a href="#" class="groups__show-filter"><?php if(isset($_GET['location']) || isset($_GET['mygroups'])): ?><?php _e('Hide Filters', 'community-portal'); ?><?php else: ?><?php _e('Show Filters', 'community-portal'); ?><?php endif; ?></a>
             </div>
             <div class="groups__groups">
                 <?php do_action('bp_before_groups_loop'); ?>
                 <?php if(sizeof($groups) === 0): ?>
-                    <div class="groups__no-results"><?php print __('No results found.  Please try another search term.', "community-portal"); ?></div>
+                    <div class="groups__no-results"><?php _e('No results found.  Please try another search term.', 'community-portal'); ?></div>
                 <?php else: ?>
                 <?php if($original_query): ?>
                 <div class="groups__results-query">
-                <?php print __("Results for ", "community-portal")."\"{$original_query}\""; ?>
+                <?php print __('Results for ', 'community-portal')."\"{$original_query}\""; ?>
                 </div>
                 <?php endif; ?>
                 <?php foreach($groups AS $group): ?>
@@ -365,7 +365,7 @@
                                         <path d="M16.3333 14.0002V12.6669C16.3328 12.0761 16.1362 11.5021 15.7742 11.0351C15.4122 10.5682 14.9053 10.2346 14.3333 10.0869" stroke="#737373" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                         <path d="M11.6667 2.08691C12.2404 2.23378 12.7488 2.56738 13.1118 3.03512C13.4749 3.50286 13.672 4.07813 13.672 4.67025C13.672 5.26236 13.4749 5.83763 13.1118 6.30537C12.7488 6.77311 12.2404 7.10671 11.6667 7.25358" stroke="#737373" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                     </svg>
-                                    <?php print "{$member_count}&nbsp;".__("Members", "community-portal"); ?>
+                                    <?php print "{$member_count}&nbsp;".__('Members', 'community-portal'); ?>
 								</div>
 							</div>
                             <div class="groups__card-info">
@@ -379,7 +379,7 @@
                                         <li class="groups__tag"><?php print $value; ?></li>
                                         <?php $tag_counter++; ?>
                                         <?php if($tag_counter === 2 && sizeof($meta['group_tags']) > 2): ?>
-                                        <li class="groups__tag">+ <?php print sizeof($meta['group_tags']) - 2; ?> <?php print __(' more tags', "community-portal"); ?></li>
+                                        <li class="groups__tag">+ <?php print sizeof($meta['group_tags']) - 2; ?> <?php _e(' more tags', 'community-portal'         ); ?></li>
                                         <?php break; ?>
                                         <?php endif; ?>
                                     <?php endforeach; ?>

--- a/buddypress/groups/single/edit.php
+++ b/buddypress/groups/single/edit.php
@@ -213,7 +213,7 @@
                 </div>
                 <div class="create-group__input-row">
                     <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-						<label class="create-group__label" for="group-telegram"><?php _e('Telegram', "community-portal"); ?></label>
+						<label class="create-group__label" for="group-telegram"><?php _e('Telegram', 'community-portal'); ?></label>
 						<input type="text" placeholder="https://" name="group_telegram" id="group-telegram" class="create-group__input create-group__input--inline"  value="<?php print isset($form['group_telegram']) ? $form['group_telegram'] : ''; ?>"/>
                     </div>
 					<div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">

--- a/buddypress/groups/single/edit.php
+++ b/buddypress/groups/single/edit.php
@@ -5,9 +5,6 @@
     $group_meta = groups_get_groupmeta($group_id, 'meta');
     $group_admins = groups_get_group_admins($group_id);
 
-
-    
-
     if($_SERVER['REQUEST_METHOD'] === 'POST') {
         $form = $_POST;
 
@@ -54,19 +51,19 @@
     <div class="create-group">
         <div class="create-group__hero">
             <div class="create-group__hero-container">
-                <h1 class="create-group__title"><?php print __("Edit Group", "community-portal"); ?></h1>
+                <h1 class="create-group__title"><?php _e('Edit Group', 'community-portal'); ?></h1>
             </div>
         </div>
         <form action="/groups/<?php print $group->slug; ?>/admin/edit-details/" method="post" id="create-group-form" class="standard-form create-group__form" enctype="multipart/form-data" novalidate>
 
         <div class="create-group__container">
             <ol class="create-group__menu">
-                <li class="create-group__menu-item create-group__menu-item--disabled"><a href="#" class="create-group__menu-link"><?php print __("Basic Information", "community-portal"); ?></a></li>
+                <li class="create-group__menu-item create-group__menu-item--disabled"><a href="#" class="create-group__menu-link"><?php _e('Basic Information', 'community-portal'); ?></a></li>
             </ol>
             <div class="create-group__menu create-group__menu--mobile">
                 <div class="create-group__select-container">
                     <select id="create-group-mobile-nav" class="create-group__select" name="mobile_nav">
-                        <option value="1" selected><?php print __("Basic Information", "community-portal"); ?></option>
+                        <option value="1" selected><?php _e('Basic Information', 'community-portal'); ?></option>
                     </select>
                 </div>
             </div>
@@ -75,28 +72,28 @@
             <section class="create-group__details">
                 <div class="create-group__input-row">
                     <div class="create-group__input-container create-group__input-container--60">
-                        <label class="create-group__label" for="group-name"><?php print __("What is your group's name? *", "community-portal"); ?></label>
+                        <label class="create-group__label" for="group-name"><?php _e('What is your group\'s name? *', 'community-portal'); ?></label>
                         <input type="text" name="group_name" id="group-name" class="create-group__input<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($form['group_name']) || (isset($form['group_name']) && empty(trim($form['group_name'])) )): ?> create-group__input--error<?php endif; ?>" value="<?php print isset($form['group_name']) ? $form['group_name'] : ''; ?>" required />
                         <div class="form__error-container<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($form['group_name']) || (isset($form['group_name']) && empty(trim($form['group_name'])) )): ?> form__error-container--visible<?php endif; ?>">
-                            <div class="form__error"><?php print __("This field is required", "community-portal"); ?></div>
+                            <div class="form__error"><?php _e('This field is required', 'community-portal'); ?></div>
                         </div>
                     </div>
                     <div class="create-group__input-container create-group__input-container--40 create-group__input-container--flex">
-                        <label class="create-group__label" for="group-type"><?php print __("Group Type", "community-portal"); ?></label>
+                        <label class="create-group__label" for="group-type"><?php _e('Group Type', 'community-portal'); ?></label>
                         <div class="create-group__select-container">
                             <select id="group-type" class="create-group__select" name="group_type" required>
-                                <option value="Online"<?php if(isset($form['group_type']) && $form['group_type'] == 'Online' || (empty($form['group_type']))): ?> selected<?php endif; ?>><?php print __("Online", "community-portal"); ?></option>
-                                <option value="Offline"<?php if(isset($form['group_type']) && $form['group_type'] == 'Offline'): ?> selected<?php endif; ?>><?php print __("Offline", "community-portal"); ?></option>
+                                <option value="Online"<?php if(isset($form['group_type']) && $form['group_type'] == 'Online' || (empty($form['group_type']))): ?> selected<?php endif; ?>><?php _e('Online', 'community-portal'); ?></option>
+                                <option value="Offline"<?php if(isset($form['group_type']) && $form['group_type'] == 'Offline'): ?> selected<?php endif; ?>><?php _e('Offline', 'community-portal'); ?></option>
                             </select>
                         </div>
                     </div>
                 </div>
                 <div class="create-group__input-row">
                     <div class="create-group__input-container create-group__input-container--full create-group__input-container--vertical-spacing">
-                        <label class="create-group__label" for="group-language"><?php print __("Language", "community-portal"); ?></label>
+                        <label class="create-group__label" for="group-language"><?php _e('Language', 'community-portal'); ?></label>
                         <div class="create-group__select-container">
                             <select id="group-language" class="create-group__select" name="group_language">
-                                <option value="0"><?php print __("Language", "community-portal"); ?></option>
+                                <option value="0"><?php _e('Language', 'community-portal'); ?></option>
                                 <?php foreach($languages AS $code =>  $language_name): ?>
                                 <option value="<?php print $code; ?>"<?php if(isset($form['group_language']) && $form['group_language'] == $code): ?> selected<?php endif; ?>><?php print $language_name; ?></option>
                                 <?php endforeach; ?>
@@ -106,10 +103,10 @@
                 </div>
                 <div class="create-group__input-row">
                     <div class="create-group__input-container  create-group__input-container--40 create-group__input-container--vertical-spacing">
-                        <label class="create-group__label" for="group-country"><?php print __("Group Location", "community-portal"); ?></label>
+                        <label class="create-group__label" for="group-country"><?php _e('Group Location', 'community-portal'); ?></label>
                         <div class="create-group__select-container">
                             <select id="group-country" class="create-group__select" name="group_country">
-                                <option value="0"><?php print __("Country", "community-portal"); ?></option>
+                                <option value="0"><?php _e('Country', 'community-portal'); ?></option>
                                 <?php foreach($countries AS $code => $country): ?>
                                 <option value="<?php print $code; ?>"<?php if(isset($form['group_country']) && $form['group_country'] === $code): ?> selected<?php endif; ?>><?php print $country; ?></option>
                                 <?php endforeach; ?>
@@ -117,20 +114,20 @@
                         </div>
                     </div>
                     <div class="create-group__input-container create-group__input-container--60 create-group__input-container--vertical-spacing">
-                        <label class="create-group__label" for="group-city"><?php print __("City", "community-portal"); ?></label>
-                        <input type="text" name="group_city" id="group-city" class="create-group__input" placeholder="<?php print __("City", "community-portal"); ?>" value="<?php print isset($form['group_city']) ? $form['group_city'] : ''; ?>" maxlength="180" />
+                        <label class="create-group__label" for="group-city"><?php _e('City', 'community-portal'); ?></label>
+                        <input type="text" name="group_city" id="group-city" class="create-group__input" placeholder="<?php _e('City', 'community-portal'); ?>" value="<?php print isset($form['group_city']) ? $form['group_city'] : ''; ?>" maxlength="180" />
                     </div>
                 </div>
                 <div class="create-group__input-row">
                     <div class="create-group__input-container create-group__input-container--60 create-group__input-container--vertical-spacing">
-                        <label class="create-group__label" for="group-desc"><?php print __("Description *", "community-portal"); ?></label>
+                        <label class="create-group__label" for="group-desc"><?php _e('Description *', 'community-portal'); ?></label>
                         <textarea name="group_desc" id="group-desc" class="create-group__textarea<?php if($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($form['group_desc']) || (isset($form['group_desc']) && empty(trim($form['group_desc'])) )): ?> create-group__input--error<?php endif; ?>" required ><?php print isset($form['group_desc']) ? $form['group_desc'] : ''; ?></textarea>
                         <div class="form__error-container<?php if(!isset($form['group_desc']) || (isset($form['group_desc']) && empty(trim($form['group_desc'])) )): ?> form__error-container--visible<?php endif; ?>">
-                            <div class="form__error"><?php print __("This field is required", "community-portal"); ?></div>
+                            <div class="form__error"><?php _e('This field is required', 'community-portal'); ?></div>
                         </div>
                     </div>
                     <div class="create-group__input-container create-group__input-container--40 create-group__input-container--vertical-spacing">
-                        <label class="create-group__label" for="group-desc"><?php print __("Group Photo", "community-portal"); ?></label>
+                        <label class="create-group__label" for="group-desc"><?php _e('Group Photo', 'community-portal'); ?></label>
                         <div id="dropzone-photo-uploader" class="create-group__image-upload<?php if(isset($form['image_url']) && strlen($form['image_url']) > 0): ?> create-group__image-upload--done<?php endif; ?>"<?php if(isset($form['image_url']) && strlen($form['image_url']) > 0): ?> style="background-image: url('<?php print $form['image_url'];?>')"<?php endif; ?>>
 							<div class="dz-message" data-dz-message="">
 								<div class="create-group__image-instructions">
@@ -138,11 +135,11 @@
 										<div class="form__error form__error--image"></div>
 									</div>
 									<button type="button" id="dropzone-trigger" class="dropzone__image-instructions create-group__image-instructions <?php echo (isset($form['image_url']) && strlen($form['image_url']) > 0 ? 'dropzone__image-instructions--hidden' : '' ) ?>">
-										<?php print __("Click or drag a photo above", "community-portal"); ?>
-										<span><?php print __('min dimensions 703px by 400px', "community-portal"); ?></span>
+										<?php _e('Click or drag a photo above', 'community-portal'); ?>
+										<span><?php _e('min dimensions 703px by 400px', 'community-portal'); ?></span>
 									</button>
 								</div>
-								<button type="button" class="dz-remove<?php if(!isset($form['image_url']) || strlen($form['image_url']) === 0): ?> dz-remove--hide<?php endif; ?>" data-dz-remove="" ><?php print __("Remove file", "community-portal"); ?></button>
+								<button type="button" class="dz-remove<?php if(!isset($form['image_url']) || strlen($form['image_url']) === 0): ?> dz-remove--hide<?php endif; ?>" data-dz-remove="" ><?php _e('Remove file', 'community-portal'); ?></button>
 							</div>
 						</div>
                         <input type="hidden" name="image_url" id="image-url" value="<?php print (isset($form['image_url']) && strlen($form['image_url']) > 0) ? $form['image_url'] : '' ?>" />
@@ -151,7 +148,7 @@
 				<div class="create-group__input-row">
 					<div class="create-group__input-container create-group__input-container--full create-group__input-container--vertical-spacing">
 						<fieldset class="fieldset">
-							<legend class="create-group__label"><?php print __("Tags for your group", "community-portal"); ?></legend>
+							<legend class="create-group__label"><?php _e('Tags for your group', 'community-portal'); ?></legend>
 							<?php 
 								// Get all tags
 								$tags = get_tags(array('hide_empty' => false));
@@ -168,72 +165,72 @@
 				</div>
             </section>
             <section class="create-group__details">
-                <div class="create-group__section-title"><?php print __("Group Meetings", "community-portal"); ?></div>
+                <div class="create-group__section-title"><?php _e('Group Meetings', 'community-portal'); ?></div>
                 <div class="create-group__input-row">
                     <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--40">    
-                        <label class="create-group__label" for="group-address-type" ><?php print __("Where do you meet?", "community-portal"); ?></label>
+                        <label class="create-group__label" for="group-address-type" ><?php _e('Where do you meet?', 'community-portal'); ?></label>
                         <div class="create-group__select-container">
                             <select class="create-group__select" name="group_address_type" id="group-address-type">
-                                <option value="<?php print __("Address", "community-portal"); ?>" <?php if(isset($form['group_address_type']) && $form['group_address_type'] == 'Address'):?> selected<?php endif;?>><?php print __("Address", "community-portal"); ?></option>
-                                <option value="<?php print __("URL", "community-portal"); ?>"<?php if(isset($form['group_address_type']) && $form['group_address_type'] == 'URL'):?> selected<?php endif;?>><?php print __("URL", "community-portal"); ?></option>
+                                <option value="Address" <?php if(isset($form['group_address_type']) && $form['group_address_type'] == 'Address'):?> selected<?php endif;?>><?php _e('Address', 'community-portal'); ?></option>
+                                <option value="URL"; ?>"<?php if(isset($form['group_address_type']) && $form['group_address_type'] == 'URL'):?> selected<?php endif;?>><?php _e('URL', 'community-portal'); ?></option>
                             </select>
                         </div>
                     </div>
                     <div class="create-group__input-container create-group__input-container--60 create-group__input-container--vertical-spacing">
-                        <label class="create-group__label" for="group-address" ><?php print __("Address", "community-portal"); ?></label>
+                        <label class="create-group__label" for="group-address" ><?php _e('Address', 'community-portal'); ?></label>
                         <input type="text" name="group_address" id="group-address" class="create-group__input" value="<?php print isset($form['group_address']) ? $form['group_address'] : ''; ?>" />
                     </div>
                 </div>
                 <div class="create-group__input-container create-group__input-container--full">
-                    <label class="create-group__label" for="group-desc"><?php print __("Meeting details", "community-portal"); ?></label>
+                    <label class="create-group__label" for="group-desc"><?php _e('Meeting details', 'community-portal'); ?></label>
                     <textarea name="group_meeting_details" id="group-meeting-details" class="create-group__textarea create-group__textarea--full create-group__textarea--short" ><?php print isset($form['group_meeting_details']) ? $form['group_meeting_details'] : ''; ?></textarea>
                 </div>
             </section>
             <section class="create-group__details">
-				<h2 class="create-group__section-title"><?php print __("Community Links", "community-portal"); ?></h2>
+				<h2 class="create-group__section-title"><?php _e('Community Links', 'community-portal'); ?></h2>
                 <div class="create-group__input-row create-group__subsection">
                     <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-						<label class="create-group__label" for="group-discourse"><?php print __("Discourse", "community-portal"); ?></label>
+						<label class="create-group__label" for="group-discourse"><?php _e('Discourse', 'community-portal'); ?></label>
 						<input placeholder="https://" type="text" name="group_discourse" id="group-discourse" class="create-group__input create-group__input--inline" value="<?php print isset($form['group_discourse']) ? $form['group_discourse'] : ''; ?>" />
                     </div>
 					<div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-						<label class="create-group__label"  for="group-matrix"><?php print __("Matrix", "community-portal"); ?></label>
+						<label class="create-group__label"  for="group-matrix"><?php _e('Matrix', 'community-portal'); ?></label>
 						<input type="text" placeholder="room-alias:domain" name="group_matrix" id="group-matrix" class="create-group__input create-group__input--inline"  value="<?php print isset($form['group_matrix']) ? $form['group_matrix'] : ''; ?>"/>
 						<div class="form__error-container form__error-container--checkbox">
-							<div class="form__error"><?php print __("Please format as room-alias:domain", "community-portal"); ?></div>
+							<div class="form__error"><?php _e('Please format as room-alias:domain', 'community-portal'); ?></div>
 						</div>
                     </div>
                 </div>
                 <div class="create-group__input-row">
                     <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-						<label class="create-group__label" for="group-facebook"><?php print __("Facebook", "community-portal"); ?></label>
+						<label class="create-group__label" for="group-facebook"><?php _e('Facebook', 'community-portal'); ?></label>
 						<input placeholder="https://" type="text" name="group_facebook" id="group-facebook" class="create-group__input create-group__input--inline"  value="<?php print isset($form['group_facebook']) ? $form['group_facebook'] : ''; ?>"/>
                     </div>
                     <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-						<label class="create-group__label" for="group-twitter"><?php print __("Twitter", "community-portal"); ?></label>
+						<label class="create-group__label" for="group-twitter"><?php _e('Twitter', 'community-portal'); ?></label>
 						<input placeholder="https://" type="text" name="group_twitter" id="group-twitter" class="create-group__input create-group__input--inline"  value="<?php print isset($form['group_twitter']) ? $form['group_twitter'] : ''; ?>"/>
                     </div>
                 </div>
                 <div class="create-group__input-row">
                     <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-						<label class="create-group__label" for="group-telegram"><?php print __("Telegram", "community-portal"); ?></label>
+						<label class="create-group__label" for="group-telegram"><?php _e('Telegram', "community-portal"); ?></label>
 						<input type="text" placeholder="https://" name="group_telegram" id="group-telegram" class="create-group__input create-group__input--inline"  value="<?php print isset($form['group_telegram']) ? $form['group_telegram'] : ''; ?>"/>
                     </div>
 					<div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-						<label class="create-group__label" for="group-github"><?php print __("GitHub", "community-portal"); ?></label>
+						<label class="create-group__label" for="group-github"><?php _e('GitHub', 'community-portal'); ?></label>
 						<input placeholder="https://" type="text" name="group_github" id="group-github" class="create-group__input create-group__input--inline"  value="<?php print isset($form['group_github']) ? $form['group_github'] : ''; ?>"/>
                     </div>
 					
                 </div>
 				<div class="create-group__input-row">
                     <div class="create-group__input-container create-group__input-container--vertical-spacing create-group__input-container--50">
-						<label class="create-group__label"  for="group-other"><?php print __("Other", "community-portal"); ?></label>
+						<label class="create-group__label"  for="group-other"><?php _e('Other', 'community-portal'); ?></label>
 						<input type="text" placeholder="https://" name="group_other" id="group-other" class="create-group__input create-group__input--inline"  value="<?php print isset($form['group_other']) ? $form['group_other'] : ''; ?>"/>
                     </div>
                 </div>
             </section>
             <section class="create-group__cta-container">
-                <input type="submit" class="create-group__cta" value="<?php print __("Continue", "community-portal"); ?>" />
+                <input type="submit" class="create-group__cta" value="<?php _e('Continue', 'community-portal'); ?>" />
             </section>
         </form>
     </div>

--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -789,13 +789,13 @@
                             <ellipse cx="8" cy="7.97569" rx="8" ry="7.97569" fill="#0060DF"/>
                             <path d="M8 5.5L8.7725 7.065L10.5 7.3175L9.25 8.535L9.545 10.255L8 9.4425L6.455 10.255L6.75 8.535L5.5 7.3175L7.2275 7.065L8 5.5Z" fill="white" stroke="white" stroke-width="2" stroke-linecap="round"/>
                         </svg>
-                        <a href="https://discourse.mozilla.org/t/frequently-asked-questions-portal-edition-faq/43224" class="group__status"><?php print __("Verified", "community-portal"); ?></a>&nbsp;|
+                        <a href="https://discourse.mozilla.org/t/frequently-asked-questions-portal-edition-faq/43224" class="group__status"><?php _e('Verified', 'community-portal'); ?></a>&nbsp;|
                     <?php else: ?>
                         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M15.5 7.97569C15.5 12.103 12.1436 15.4514 8 15.4514C3.85643 15.4514 0.5 12.103 0.5 7.97569C0.5 3.84842 3.85643 0.5 8 0.5C12.1436 0.5 15.5 3.84842 15.5 7.97569Z" stroke="#B1B1BC"/>
                             <path d="M8 5.5L8.7725 7.065L10.5 7.3175L9.25 8.535L9.545 10.255L8 9.4425L6.455 10.255L6.75 8.535L5.5 7.3175L7.2275 7.065L8 5.5Z" fill="#B1B1BC" stroke="#B1B1BC" stroke-width="2" stroke-linecap="round"/>
                         </svg>
-                        <a href="https://discourse.mozilla.org/t/frequently-asked-questions-portal-edition-faq/43224" class="group__status"><?php print __("Unverified", "community-portal"); ?></a>&nbsp;|
+                        <a href="https://discourse.mozilla.org/t/frequently-asked-questions-portal-edition-faq/43224" class="group__status"><?php _e('Unverified', 'community-portal'); ?></a>&nbsp;|
                     <?php endif; ?>
                     <span class="group__location">
                     <?php 
@@ -825,32 +825,33 @@
                     </span>
                     <span class="group__created">
                     <?php
-                        $created = date("F d, Y", strtotime($group->date_created));
-                        print "<span> Created {$created}";
+						$created = date("F d, Y", strtotime($group->date_created));
+						$created_word = __('Created', 'community-portal');
+                        print "<span> {$created_word} {$created}";
                     ?>
                     </span>
                 </div>
                 <div class="group__nav">
                     <ul class="group__menu">
-                        <li class="menu-item"><a class="group__menu-link<?php if(bp_is_group_home() && !$is_events && !$is_people): ?> group__menu-link--active<?php endif; ?>" href="/groups/<?php print $group->slug; ?>"><?php print __("About us", "community-portal"); ?></a></li>
-                        <li class="menu-item"><a class="group__menu-link<?php if($is_events): ?> group__menu-link--active<?php endif; ?>" href="/groups/<?php print $group->slug; ?>?view=events"><?php print __("Our Events", "community-portal"); ?></a></li>
-                        <li class="menu-item"><a class="group__menu-link<?php if($is_people): ?> group__menu-link--active<?php endif; ?>" href="/groups/<?php print $group->slug; ?>/?view=people"><?php print __("Our Members", "community-portal"); ?></a></li>
+                        <li class="menu-item"><a class="group__menu-link<?php if(bp_is_group_home() && !$is_events && !$is_people): ?> group__menu-link--active<?php endif; ?>" href="/groups/<?php print $group->slug; ?>"><?php _e('About us', 'community-portal'); ?></a></li>
+                        <li class="menu-item"><a class="group__menu-link<?php if($is_events): ?> group__menu-link--active<?php endif; ?>" href="/groups/<?php print $group->slug; ?>?view=events"><?php _e('Our Events', 'community-portal'); ?></a></li>
+                        <li class="menu-item"><a class="group__menu-link<?php if($is_people): ?> group__menu-link--active<?php endif; ?>" href="/groups/<?php print $group->slug; ?>/?view=people"><?php _e('Our Members', 'community-portal'); ?></a></li>
                     </ul>
                 </div>
                 <div class="group__nav group__nav--mobile">
-                    <label class="group__nav-select-label"><?php print __('Showing', "community-portal"); ?></label>
+                    <label class="group__nav-select-label"><?php _e('Showing', 'community-portal'); ?></label>
                     <div class="select-container">
                         <select class="group__nav-select">
-                            <option value="/groups/<?php print $group->slug; ?>"<?php if(bp_is_group_home() && !$is_events && !$is_people): ?> selected<?php endif; ?>><?php print __("About us", "community-portal"); ?></option>
-                            <option value="/groups/<?php print $group->slug; ?>?view=events"<?php if($is_events): ?> selected<?php endif; ?>><?php print __("Our Events", "community-portal"); ?></option>
-                            <option value="/groups/<?php print $group->slug; ?>?view=people"<?php if($is_people): ?> selected<?php endif; ?>><?php print __("Our Members", "community-portal"); ?></option>
+                            <option value="/groups/<?php print $group->slug; ?>"<?php if(bp_is_group_home() && !$is_events && !$is_people): ?> selected<?php endif; ?>><?php _e('About us', 'community-portal'); ?></option>
+                            <option value="/groups/<?php print $group->slug; ?>?view=events"<?php if($is_events): ?> selected<?php endif; ?>><?php _e('Our Events', 'community-portal'); ?></option>
+                            <option value="/groups/<?php print $group->slug; ?>?view=people"<?php if($is_people): ?> selected<?php endif; ?>><?php _e('Our Members', 'community-portal'); ?></option>
                         </select>
                     </div>
                 </div>
                 <section class="group__info">
                     <?php if($is_people): ?>
                     <div class="group__members-container">
-                        <h2 class="group__card-title"><?php print __("Group Contacts", "community-portal")." ({$admin_count})"; ?></h2>
+                        <h2 class="group__card-title"><?php _e('Group Contacts','community-portal')." ({$admin_count})"; ?></h2>
                         <div class="group__members">
                             <?php foreach($admins AS $admin): ?>
                             <?php 
@@ -898,7 +899,7 @@
                         </div>
 
 				
-                        <h2 class="group__card-title"><?php print __("People", "community-portal"); ?><?php echo " ({$members['count']})" ?></h2>
+                        <h2 class="group__card-title"><?php _e('People', 'community-portal'); ?><?php echo " ({$members['count']})" ?></h2>
 						<?php if ($members['count'] > 0): ?>
 						<div class="members__search-container">
 								<form method="GET" action="<?php echo $_SERVER['REQUEST_URI'] ?>" class="members__form" id="members-search-form">
@@ -911,17 +912,17 @@
 									<input type="hidden" value="<?php if(isset($_GET['tag']) && strlen($_GET['tag']) > 0): print htmlspecialchars(trim($_GET['tag']), ENT_QUOTES, 'utf-8'); endif; ?>" name="tag" id="user-tag" />
 									<input type="hidden" value="<?php if(isset($_GET['location']) && strlen($_GET['location']) > 0): print htmlspecialchars(trim($_GET['location']), ENT_QUOTES, 'utf-8'); endif; ?>" name="location" id="user-location" />
 									<input type="hidden" value="<?php if(isset($_GET['language']) && strlen($_GET['language']) > 0): print htmlspecialchars(trim($_GET['language']), ENT_QUOTES, 'utf-8'); endif; ?>" name="language" id="user-language" />
-									<input type="text" name="u" id="members-search" class="members__search-input" placeholder="<?php print __("Search people", "community-portal"); ?>" value="<?php if($search_user): ?><?php print $search_user; ?><?php endif; ?>" />
+									<input type="text" name="u" id="members-search" class="members__search-input" placeholder="<?php _e('Search people', 'community-portal'); ?>" value="<?php if($search_user): ?><?php print $search_user; ?><?php endif; ?>" />
 									</div>
-									<input type="submit" class="members__search-cta" value="<?php print __("Search", "community-portal"); ?>" />
+									<input type="submit" class="members__search-cta" value="<?php _e('Search', 'community-portal'); ?>" />
 								</form>
 							</div>
 							<div class="members__filter-container members__filter-container--hidden">
-								<span><?php print __("Search criteria:", "community-portal"); ?></span>
+								<span><?php _e('Search criteria:', 'community-portal'); ?></span>
 								<div class="members__select-container">
-									<label class="members__label"><?php print __("Location", "community-portal"); ?></label>
+									<label class="members__label"><?php _e('Location', 'community-portal'); ?></label>
 									<select class="members__location-select">
-										<option value=""><?php print __('Select', "community-portal"); ?></option>
+										<option value=""><?php _e('Select', 'community-portal'); ?></option>
 										<?php foreach($used_country_list AS $code   =>  $country): ?>
 										<option value="<?php print $code; ?>"<?php if(isset($_GET['location']) && strlen($_GET['location']) > 0 && $_GET['location'] == $code): ?> selected<?php endif; ?>><?php print $country; ?></option>
 										<?php endforeach; ?>
@@ -929,9 +930,9 @@
 								</div>
 								<?php if(sizeof($used_languages) > 0): ?>
 								<div class="members__select-container">
-									<label class="members__label"><?php print __("Language", "community-portal"); ?></label>
+									<label class="members__label"><?php _e('Language', 'community-portal'); ?></label>
 									<select class="members__language-select">
-										<option value=""><?php print __('Select', "community-portal"); ?></option>
+										<option value=""><?php _e('Select', 'community-portal'); ?></option>
 										<?php foreach($used_languages AS $code =>   $language): ?>
 										<?php if(strlen($code) > 1): ?>
 										<option value="<?php print $code; ?>" <?php if(isset($_GET['language']) && strtolower(trim($_GET['language'])) == strtolower($code)): ?> selected<?php endif; ?>><?php print $language; ?></option>
@@ -941,9 +942,9 @@
 								</div>
 								<?php endif; ?>
 								<div class="members__select-container">
-									<label class="members__label"><?php print __("Tag", "community-portal"); ?></label>
+									<label class="members__label"><?php _e('Tag', 'community-portal'); ?></label>
 									<select class="members__tag-select">
-										<option value=""><?php print __('Select', "community-portal"); ?></option>
+										<option value=""><?php _e('Select', 'community-portal'); ?></option>
 										<?php foreach($tags AS $tag): ?>
 										<option value="<?php print $tag->slug; ?>" <?php if(isset($_GET['tag']) && strtolower(trim($_GET['tag'])) == strtolower($tag->slug)): ?> selected<?php endif; ?>><?php print $tag->name; ?></option>
 										<?php endforeach; ?>
@@ -951,12 +952,12 @@
 								</div>
 							</div>
 							<div class="members__show-filters-container">
-								<a href="#" class="members__show-filter"><?php print __("Show Filters", "community-portal"); ?></a>
+								<a href="#" class="members__show-filter"><?php _e('Show Filters', 'community-portal'); ?></a>
 							</div>
 						
                         <div class="group__members">
 						<?php if(sizeof($filtered_members) > 0): ?>
-							<?php if(isset($_GET['u']) && strlen($_GET['u']) > 0): ?><div class="members__results-for"><?php print __(sprintf("Results for \"%s\"", $search_user), "community-portal"). " ({$count})"; ?></div>
+							<?php if(isset($_GET['u']) && strlen($_GET['u']) > 0): ?><div class="members__results-for"><?php  _e(sprintf('Results for \"%s\"', $search_user), 'community-portal'). " ({$count})"; ?></div>
 							<?php endif; ?>			
                             <?php foreach($filtered_members AS $member): ?>
                             <?php
@@ -1000,11 +1001,11 @@
                             </a>
                             <?php endforeach; ?>
 							<?php else: ?>
-								<h2 class="members__title--no-members-found"><?php print __('No members found', "community-portal"); ?></h2>
+								<h2 class="members__title--no-members-found"><?php _e('No members found', 'community-portal'); ?></h2>
 							<?php endif; ?>
                         </div>  
 						<?php else: ?>
-							<p><?php print __('This group currently has no members', "community-portal"); ?></p>
+							<p><?php _e('This group currently has no members', 'community-portal'); ?></p>
 						<?php endif; ?>
                     </div>
                     <?php elseif($is_events === true): ?>
@@ -1073,7 +1074,7 @@
                                                 <p class="text--light text--small">
                                                     <?php
                                                         if($location->country === 'OE') {
-                                                            echo __('Online Event', "community-portal");
+                                                            _e('Online Event', 'community-portal');
                                                         } else {
                                                             if ($location->address) {
                                                                 echo $location->address.' - '; 
@@ -1147,10 +1148,10 @@
                                 <div class="group__card-cta-container<?php if($is_admin): ?> group__card-cta-container--end<?php endif; ?>">
                                 <?php if(!$is_admin): ?>
                                     <?php if($is_member): ?>
-                                        <a href="#" class="group__leave-cta" data-group="<?php print $group->id; ?>"><?php print __('Leave Group', "community-portal"); ?></a>
+                                        <a href="#" class="group__leave-cta" data-group="<?php print $group->id; ?>"><?php _e('Leave Group', 'community-portal'); ?></a>
                                     <?php else: ?>
                                         <?php if($invite_status === 'members' || $invite_status === ""): ?>
-                                            <a href="#" class="group__join-cta" data-group="<?php print $group->id; ?>"><?php print __('Join Group', "community-portal"); ?></a>
+                                            <a href="#" class="group__join-cta" data-group="<?php print $group->id; ?>"><?php _e('Join Group', 'community-portal'); ?></a>
                                         <?php endif; ?>
                                     <?php endif; ?>
                                 <?php endif; ?>
@@ -1158,11 +1159,11 @@
                                     <svg width="14" height="18" viewBox="0 0 14 18" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <path d="M1 9V15C1 15.3978 1.15804 15.7794 1.43934 16.0607C1.72064 16.342 2.10218 16.5 2.5 16.5H11.5C11.8978 16.5 12.2794 16.342 12.5607 16.0607C12.842 15.7794 13 15.3978 13 15V9M10 4.5L7 1.5M7 1.5L4 4.5M7 1.5V11.25" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                     </svg>
-                                    <?php print __('Share Group', "community-portal"); ?>
+                                    <?php _e('Share Group', 'community-portal'); ?>
                                 </a>
                                 </div>
                                 <hr class="group__keyline" />
-                                <h2 class="group__card-title"><?php print __("About Us", "community-portal"); ?></h2>
+                                <h2 class="group__card-title"><?php _e('About Us', 'community-portal'); ?></h2>
                                 <?php print wpautop(substr(trim($group->description), 0, 3000)); ?>
                                 <?php if((isset($group_meta['group_telegram']) && strlen($group_meta['group_telegram']) > 0 ) 
                                 || (isset($group_meta['group_facebook']) && strlen(trim($group_meta['group_facebook'])) > 0 ) 
@@ -1172,7 +1173,7 @@
                                 || (isset($group_meta['group_matrix']) && strlen(trim($group_meta['group_matrix'])) > 0 )  
                                 || (isset($group_meta['group_other']) && strlen($group_meta['group_other']) > 0)): ?>
                                 <div class="group__community-links">
-                                    <span class="no-line"><?php print __("Community Links", "community-portal"); ?></span>
+                                    <span class="no-line"><?php _e('Community Links', 'community-portal'); ?></span>
                                     <?php if(isset($group_meta['group_telegram']) && strlen($group_meta['group_telegram']) > 0): ?>
                                         <div class="group__community-link-container">
                                             <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -1180,7 +1181,7 @@
                                                 <path d="M24.3332 7.66699L15.1665 16.8337" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                                 <path d="M24.3332 7.66699L18.4998 24.3337L15.1665 16.8337L7.6665 13.5003L24.3332 7.66699Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                             </svg>
-                                            <a href="<?php print (mozilla_verify_url($group_meta['group_telegram'], false) ? mozilla_verify_url($group_meta['group_telegram'], false) : 'https://t.me/'.$group_meta['group_telegram']) ?>" class="group__social-link"><?php print __("Telegram", "community-portal"); ?></a>
+                                            <a href="<?php print (mozilla_verify_url($group_meta['group_telegram'], false) ? mozilla_verify_url($group_meta['group_telegram'], false) : 'https://t.me/'.$group_meta['group_telegram']) ?>" class="group__social-link"><?php _e('Telegram', 'community-portal'); ?></a>
                                         </div>
 									<?php endif; ?>
                                     <?php if(isset($group_meta['group_facebook']) && strlen(trim($group_meta['group_facebook'])) > 0): ?>
@@ -1189,7 +1190,7 @@
                                                 <circle cx="16" cy="16" r="16" fill="#CDCDD4"/>
                                                 <path fill-rule="evenodd" clip-rule="evenodd" d="M26 16C26 10.4771 21.5229 6 16 6C10.4771 6 6 10.4771 6 16C6 20.9913 9.65686 25.1283 14.4375 25.8785V18.8906H11.8984V16H14.4375V13.7969C14.4375 11.2906 15.9304 9.90625 18.2146 9.90625C19.3087 9.90625 20.4531 10.1016 20.4531 10.1016V12.5625H19.1921C17.9499 12.5625 17.5625 13.3333 17.5625 14.1242V16H20.3359L19.8926 18.8906H17.5625V25.8785C22.3431 25.1283 26 20.9913 26 16Z" fill="black"/>
                                             </svg>
-                                            <a href="<?php echo (mozilla_verify_url($group_meta['group_facebook'], true) ? mozilla_verify_url($group_meta['group_facebook'], true): 'https://www.facebook.com/'. $group_meta['group_facebook']); ?>" class="group__social-link"><?php print __("Facebook", "community-portal"); ?></a>
+                                            <a href="<?php echo (mozilla_verify_url($group_meta['group_facebook'], true) ? mozilla_verify_url($group_meta['group_facebook'], true): 'https://www.facebook.com/'. $group_meta['group_facebook']); ?>" class="group__social-link"><?php _e('Facebook', 'community-portal'); ?></a>
                                         </div>
                                     <?php endif; ?>
                                     <?php if(isset($group_meta['group_discourse']) && strlen(trim($group_meta['group_discourse'])) > 0): ?>
@@ -1198,7 +1199,7 @@
                                                 <circle cx="16" cy="16" r="16" fill="#CDCDD4"/>
                                                 <path d="M23.5 15.5834C23.5029 16.6832 23.2459 17.7683 22.75 18.75C22.162 19.9265 21.2581 20.916 20.1395 21.6078C19.021 22.2995 17.7319 22.6662 16.4167 22.6667C15.3168 22.6696 14.2318 22.4126 13.25 21.9167L8.5 23.5L10.0833 18.75C9.58744 17.7683 9.33047 16.6832 9.33333 15.5834C9.33384 14.2682 9.70051 12.9791 10.3923 11.8605C11.084 10.7419 12.0735 9.838 13.25 9.25002C14.2318 8.75413 15.3168 8.49716 16.4167 8.50002H16.8333C18.5703 8.59585 20.2109 9.32899 21.4409 10.5591C22.671 11.7892 23.4042 13.4297 23.5 15.1667V15.5834Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 											</svg>
-                                            <a href="<?php echo (mozilla_verify_url($group_meta['group_discourse'], true) ? mozilla_verify_url($group_meta['group_discourse'], true) : 'https://discourse.mozilla.org/u/'. $group_meta['group_discourse'] .'/summary') ?>" class="group__social-link"><?php print __("Discourse", "community-portal"); ?></a>
+                                            <a href="<?php echo (mozilla_verify_url($group_meta['group_discourse'], true) ? mozilla_verify_url($group_meta['group_discourse'], true) : 'https://discourse.mozilla.org/u/'. $group_meta['group_discourse'] .'/summary') ?>" class="group__social-link"><?php _e('Discourse', 'community-portal'); ?></a>
                                         </div>
                                     <?php endif; ?>
                                     <?php if(isset($group_meta['group_github']) && strlen(trim($group_meta['group_github'])) > 0): ?>
@@ -1214,7 +1215,7 @@
                                                 </clipPath>
                                                 </defs>
                                             </svg>
-                                            <a href="<?php print (mozilla_verify_url($group_meta['group_github'], true) ? mozilla_verify_url($group_meta['group_github'], true) : 'https://www.github.com/'.$group_meta['group_github']); ?>" class="group__social-link"><?php print __("Github", "community-portal"); ?></a>
+                                            <a href="<?php print (mozilla_verify_url($group_meta['group_github'], true) ? mozilla_verify_url($group_meta['group_github'], true) : 'https://www.github.com/'.$group_meta['group_github']); ?>" class="group__social-link"><?php _e('Github', 'community-portal'); ?></a>
                                         </div>
                                     <?php endif; ?>
                                     <?php if(isset($group_meta['group_twitter']) && strlen(trim($group_meta['group_twitter'])) > 0): ?>
@@ -1223,7 +1224,7 @@
                                                 <circle cx="16" cy="16" r="16" fill="#CDCDD4"/>
                                                 <path d="M12.3766 23.9366C19.7469 23.9366 23.7781 17.8303 23.7781 12.535C23.7781 12.3616 23.7781 12.1889 23.7664 12.017C24.5506 11.4498 25.2276 10.7474 25.7656 9.94281C25.0343 10.2669 24.2585 10.4794 23.4641 10.5733C24.3006 10.0725 24.9267 9.28482 25.2258 8.35688C24.4392 8.82364 23.5786 9.15259 22.6812 9.32953C22.0771 8.6871 21.278 8.26169 20.4077 8.11915C19.5374 7.97661 18.6444 8.12487 17.8668 8.541C17.0893 8.95713 16.4706 9.61792 16.1064 10.4211C15.7422 11.2243 15.6529 12.1252 15.8523 12.9842C14.2592 12.9044 12.7006 12.4903 11.2778 11.7691C9.85506 11.0478 8.59987 10.0353 7.59375 8.7975C7.08132 9.67966 6.92438 10.724 7.15487 11.7178C7.38536 12.7116 7.98596 13.5802 8.83437 14.1467C8.19667 14.1278 7.57287 13.9558 7.01562 13.6452C7.01562 13.6616 7.01562 13.6788 7.01562 13.6959C7.01588 14.6211 7.33614 15.5177 7.9221 16.2337C8.50805 16.9496 9.32362 17.4409 10.2305 17.6241C9.64052 17.785 9.02155 17.8085 8.42109 17.6928C8.67716 18.489 9.17568 19.1853 9.84693 19.6843C10.5182 20.1832 11.3286 20.4599 12.1648 20.4756C10.7459 21.5908 8.99302 22.1962 7.18828 22.1944C6.86946 22.1938 6.55094 22.1745 6.23438 22.1366C8.0669 23.3126 10.1992 23.9363 12.3766 23.9334" fill="black"/>
                                             </svg>
-                                            <a href="<?php print (mozilla_verify_url($group_meta['group_twitter'], true) ? mozilla_verify_url($group_meta['group_twitter'], true) : 'https://www.twitter.com/'.$group_meta['group_twitter']) ?>" class="group__social-link"><?php print __("Twitter", "community-portal"); ?></a>
+                                            <a href="<?php print (mozilla_verify_url($group_meta['group_twitter'], true) ? mozilla_verify_url($group_meta['group_twitter'], true) : 'https://www.twitter.com/'.$group_meta['group_twitter']) ?>" class="group__social-link"><?php _e('Twitter', 'community-portal'); ?></a>
                                         </div>
                                     <?php endif; ?>
 									<?php if(isset($group_meta['group_matrix']) && strlen(trim($group_meta['group_matrix'])) > 0): ?>
@@ -1238,7 +1239,7 @@
 												<line x1="7" y1="9" x2="7" y2="23" stroke="black" stroke-width="2"/>
 												<line x1="25" y1="9" x2="25" y2="23" stroke="black" stroke-width="2"/>
 											</svg>
-                                            <a href="<?php print (mozilla_verify_url($group_meta['group_matrix'], true) ? mozilla_verify_url($group_meta['group_matrix'], true) : 'https://chat.mozilla.org/#/room/#'.$group_meta['group_matrix']) ?>" class="group__social-link"><?php print __("Matrix", "community-portal"); ?></a>
+                                            <a href="<?php print (mozilla_verify_url($group_meta['group_matrix'], true) ? mozilla_verify_url($group_meta['group_matrix'], true) : 'https://chat.mozilla.org/#/room/#'.$group_meta['group_matrix']) ?>" class="group__social-link"><?php _e('Matrix', 'community-portal'); ?></a>
                                         </div>
                                     <?php endif; ?>
                                     <?php if(isset($group_meta['group_other']) && strlen($group_meta['group_other']) > 0 && mozilla_verify_url($group_meta['group_other'], false)): ?>
@@ -1257,7 +1258,7 @@
                                                 </clipPath>
                                                 </defs>
                                             </svg>
-                                            <a href="<?php print mozilla_verify_url($group_meta['group_other'], false); ?>" class="group__social-link"><?php print __("Other", "community-portal"); ?></a>
+                                            <a href="<?php print mozilla_verify_url($group_meta['group_other'], false); ?>" class="group__social-link"><?php _e('Other', 'community-portal'); ?></a>
                                         </div>
                                     <?php endif; ?>
                                 </div>
@@ -1265,10 +1266,10 @@
                             </div>
                         </div>
                         <?php if((isset($group_meta['group_meeting_details'])  && $group_meta['group_meeting_details']) || (isset($group_meta['group_address']) && $group_meta['group_address'])): ?>
-                        <h2 class="group__card-title"><?php print __('Meetings', "community-portal"); ?></h2>
+                        <h2 class="group__card-title"><?php _e('Meetings', 'community-portal'); ?></h2>
                         <div class="group__card">
                             <div class="group__card-content">
-                                <span class="no-line"><?php print __('Meeting Details', "community-portal"); ?></span>
+                                <span class="no-line"><?php _e('Meeting Details', 'community-portal'); ?></span>
                                 <?php if(isset($group_meta['group_meeting_details'])): ?>
                                 <p class="group__card-copy">
                                     <?php print $group_meta['group_meeting_details']; ?>
@@ -1278,7 +1279,7 @@
                                 <hr />
                                 <?php endif; ?>
                                 <?php if(isset($group_meta['group_address']) && $group_meta['group_address']): ?>
-                                <span class="no-line"><?php print __('Location', "community-portal"); ?></span>
+                                <span class="no-line"><?php _e('Location', 'community-portal'); ?></span>
                                 <?php if(isset($group_meta['group_address_type']) && strtolower($group_meta['group_address_type']) == 'url'): ?>
                                     <div>
                                         <a class="group__meeting-location-link" href="<?php print $group_meta['group_address']; ?>" target="_blank"><?php print $group_meta['group_address']; ?></a>
@@ -1307,16 +1308,16 @@
                             }
                         ?>
                         <?php if(sizeof($topics) > 0): ?>
-                        <h2 class="group__card-title"><?php print __('Discussions', "community-portal"); ?></h2>
+                        <h2 class="group__card-title"><?php _e('Discussions', 'community-portal'); ?></h2>
                         <div class="group__card group__card--table">
                             <div class="group__card-content">
                                 <table class="group__announcements">
                                     <thead>
                                         <tr>
-                                            <th class="group__table-header group__table-header--topic"><?php print __('Topic', "community-portal"); ?></th>
-                                            <th class="group__table-header"><?php print __('Replies', "community-portal"); ?></th>
-                                            <th class="group__table-header"><?php print __('Views', "community-portal"); ?></th>
-                                            <th class="group__table-header group__table-header--activity"><?php print __('Activity', "community-portal"); ?></th>
+                                            <th class="group__table-header group__table-header--topic"><?php _e('Topic', 'community-portal'); ?></th>
+                                            <th class="group__table-header"><?php _e('Replies', 'community-portal'); ?></th>
+                                            <th class="group__table-header"><?php _e('Views', 'community-portal'); ?></th>
+                                            <th class="group__table-header group__table-header--activity"><?php _e('Activity', 'community-portal'); ?></th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -1345,7 +1346,7 @@
                                         <tr>
                                             <td colspan="4" class="group__table-cell group__table-cell--topic">
                                                 <a href="<?php print $discourse_group['discourse_category_url']; ?>" class="group__view-updates-link">
-                                                    <?php print __('View more topics', "community-portal"); ?><svg width="8" height="10" viewBox="0 0 8 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                    <?php _e('View more topics', 'community-portal'); ?><svg width="8" height="10" viewBox="0 0 8 10" fill="none" xmlns="http://www.w3.org/2000/svg">
                                                         <path d="M2.33301 8.66732L5.99967 5.00065L2.33301 1.33398" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                                                     </svg>
                                                 </a>
@@ -1362,7 +1363,7 @@
                     <div class="group__right-column">
                         <div class="group__card">
                             <div class="group__card-content group__card-content--small">
-                                <span><?php print __('Activity', "community-portal"); ?></span>
+                                <span><?php _e('Activity', 'community-portal'); ?></span>
                                 <?php 
                                     $args = Array(
                                         'group'     => $group->id,
@@ -1378,7 +1379,7 @@
                                 </div>
                                 <div class="group__member-count-container">
                                     <a href="/groups/<?php print $group->slug?>?view=people" class="group__member-count"><?php print $member_count; ?></a>
-                                    Members
+                                    <?php _e('Members', 'community-portal'); ?>
                                 </div>
                             </div>
                         </div>
@@ -1400,7 +1401,7 @@
                         <?php if($event): ?>
                         <div class="group__card">
                             <div class="group__card-content group__card-content--small">
-                                <span><?php print __('Related Events', "community-portal"); ?></span>
+                                <span><?php _e('Related Events', 'community-portal'); ?></span>
                                 <a class="group__event" href="/events/<?php print $event->event_slug; ?>"> 
                                     <div class="group__event-date">
                                         <?php print $event_date; ?>
@@ -1416,7 +1417,7 @@
                                                 <path d="M8 9.66602C9.10457 9.66602 10 8.77059 10 7.66602C10 6.56145 9.10457 5.66602 8 5.66602C6.89543 5.66602 6 6.56145 6 7.66602C6 8.77059 6.89543 9.66602 8 9.66602Z" stroke="#737373" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                                             </svg>
                                             <?php if($location->location_country === 'OE'): ?>
-											<?php print __("Online Event", "community-portal"); ?>
+											<?php _e('Online Event', 'community-portal'); ?>
                                             <?php elseif($location->location_town && $location->location_country): ?>
                                                 <?php print "{$location->location_town}, {$countries[$location->location_country]}"; ?>
                                             <?php elseif($location->location_town && !$location->location_country): ?>
@@ -1428,14 +1429,14 @@
                                     </div>
                                 </a>
                                 <a href="/groups/<?php print $group->slug; ?>/?view=events" class="group__events-link">
-                                    <?php print __('View more events', "community-portal"); ?><svg width="8" height="10" viewBox="0 0 8 10" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.33301 8.66634L5.99967 4.99967L2.33301 1.33301" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                                    <?php _e('View more events', 'community-portal'); ?><svg width="8" height="10" viewBox="0 0 8 10" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.33301 8.66634L5.99967 4.99967L2.33301 1.33301" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
                                 </a>
                             </div>
                         </div>
                         <?php endif; ?>
                         <div class="group__card">
                             <div class="group__card-content group__card-content--small">
-                                <span><?php print __('Group Contacts', "community-portal"); ?></span> 
+                                <span><?php _e('Group Contacts', 'community-portal'); ?></span> 
                                 <div class="group__admins">
                                     <?php foreach($admins AS $admin): ?>
                                     <?php
@@ -1477,7 +1478,7 @@
                         <?php if(strlen($group_meta['group_language']) > 0 && array_key_exists(strtolower($group_meta['group_language']), $languages)): ?>
                         <div class="group__card">
                             <div class="group__card-content group__card-content--small">
-                                <span><?php print __('Preferred Language', "community-portal"); ?></span>
+                                <span><?php _e('Preferred Language', 'community-portal'); ?></span>
                                 <div class="group__tags">
                                     <div class="group__language">
                                         <a href="/groups/?language=<?php print strtolower($group_meta['group_language']); ?>" class="group__language-link"><?php print $languages[strtolower($group_meta['group_language'])]; ?></a>
@@ -1489,7 +1490,7 @@
                         <?php if(sizeof(array_unique($group_meta['group_tags'])) > 0): ?>
                         <div class="group__card">
                             <div class="group__card-content group__card-content--small">
-                                <span><?php print __('Tags', "community-portal"); ?></span>
+                                <span><?php _e('Tags', 'community-portal'); ?></span>
                                 <div class="group__tags">
                                     <?php foreach(array_unique($group_meta['group_tags']) AS $tag): ?>
                                     <a href="/groups/?tag=<?php print $tag; ?>" class="group__tag"><?php print $tag; ?></a>
@@ -1503,13 +1504,13 @@
                 </section>
                 <?php if(isset($options['report_email']) && is_user_logged_in()): ?>
                 <div class="group__report-container">
-                    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Group', 'community-portal'), $group->name); ?>&body=<?php print __(sprintf('Please provide a reason you are reporting this group    %s', "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}"), 'community-portal'); ?>" class="group__report-group-link">
+                    <a href="mailto:<?php print $options['report_email']; ?>?subject=<?php print sprintf('%s %s', __('Reporting Group', 'community-portal'), $group->name); ?>&body=<?php _e(sprintf('Please provide a reason you are reporting this group    %s', "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}"), 'community-portal'); ?>" class="group__report-group-link">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             <path d="M12 8V12" stroke="#0060DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             <circle cx="12" cy="16" r="0.5" fill="#CDCDD4" stroke="#0060DF"/>
                         </svg>
-                        <?php print __("Report Group", 'community-portal'); ?>
+                        <?php _e('Report Group', 'community-portal'); ?>
                     </a>
                 </div>
                 <?php endif; ?>

--- a/functions.php
+++ b/functions.php
@@ -75,6 +75,9 @@ add_action('add_meta_boxes', 'mozilla_campaign_metabox');
 add_action('wp_ajax_download_activity_events', 'mozilla_download_activity_events');
 add_action('add_meta_boxes', 'mozilla_activity_metabox');
 
+add_action('after_setup_theme', 'mozilla_theme_setup');
+
+
 // Auth0 Actions
 add_action('auth0_user_login', 'mozilla_post_user_creation', 10, 6);
 
@@ -108,6 +111,14 @@ add_filter('query_vars', 'mozilla_add_query_vars_filter');
 add_filter('bp_groups_list_table_get_columns', 'mozilla_add_group_columns');
 add_filter('bp_groups_admin_get_group_custom_column', 'mozilla_group_addional_column_info', 10, 3);
 add_filter('wp_nav_menu_objects', 'mozilla_hide_menu_emails', 10, 2);
+
+
+function mozilla_theme_setup() {
+    load_theme_textdomain('community-portal', get_template_directory() . '/languages');
+
+
+    
+}
 
 
 // Include theme style.css file not in admin page

--- a/lib/groups.php
+++ b/lib/groups.php
@@ -194,7 +194,7 @@ function mozilla_edit_group() {
                 if(isset($_POST['group_name'])) {
                     $error = mozilla_search_groups($_POST['group_name'], $group_id);
                     if($error) {
-                        $_POST['group_name_error'] = __('This group name is already taken', "community-portal");
+                        $_POST['group_name_error'] = __('This group name is already taken', 'community-portal');
                     }
                 }
 
@@ -338,9 +338,9 @@ function mozilla_join_group() {
                         $discourse = mozilla_discourse_api('groups/users', $discourse_api_data, 'patch');
                 
     
-                        print json_encode(Array('status'   =>  'success', 'msg'  =>  __('Joined Group', "community-portal")));
+                        print json_encode(Array('status'   =>  'success', 'msg'  =>  __('Joined Group', 'community-portal')));
                     } else {
-                        print json_encode(Array('status'   =>  'error', 'msg'   =>  __('Could not join group', "community-portal")));
+                        print json_encode(Array('status'   =>  'error', 'msg'   =>  __('Could not join group', 'community-portal')));
                     }
                 }
                 
@@ -469,7 +469,7 @@ function mozilla_save_group($group_id) {
 }
 
 function mozilla_group_metabox() {
-    add_meta_box('mozilla-group-metabox', __( 'Export Events' ), 'mozilla_group_markup_metabox', get_current_screen()->id, 'side', 'core');
+    add_meta_box('mozilla-group-metabox', __('Export Events', 'community-portal'), 'mozilla_group_markup_metabox', get_current_screen()->id, 'side', 'core');
 }
 
 function mozilla_group_markup_metabox($post) {

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1,3 +1,9 @@
+/**
+* Theme Name: Community Portal
+* Text Domain: community-portal
+*
+**/
+
 @import "normalize/normalize";
 
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:400,600&display=swap");


### PR DESCRIPTION
Had to update the gettext functions for groups.  Will continue for other sections.  But please review, make sure all gettext functions use single quotes and instead of print __ we use _e to echo values out if assigning to a variable __ is ok.  Make sure all functionality still works and displays all messages for creating, editing and viewing a group.

Was able to run this through POEdit and get string translations into a .po file.  I haven't compared the strings in the po file with the strings on the page so perhaps that is something to do as well.