### PR TITLE
Fix remove button not showing

### DIFF
--- a/buddypress/members/single/edit.php
+++ b/buddypress/members/single/edit.php
@@ -112,6 +112,7 @@ $subscribed = get_user_meta( $user->ID, 'newsletter', true );
 else :
 	?>
 							<?php
+
 							if ( is_array( $community_fields ) && isset( $community_fields['image_url'] ) && strlen( $community_fields['image_url'] ) > 0 ) :
 								?>
 	style="background: url('<?php echo esc_url_raw( $avatar_url ); ?>'); background-size: cover;"<?php endif; ?><?php endif; ?>>
@@ -122,7 +123,7 @@ else :
 									</div>
 									<button id="dropzone-trigger" type="button" class="dropzone__image-instructions profile__image-instructions 
 									<?php
-									if ( isset( $community_fields['image_url'] ) || strlen( $community_fields['image_url'] ) !== 0 ) :
+									if ( isset( $community_fields['image_url'] ) && strlen( $community_fields['image_url'] ) !== 0 ) :
 										?>
 										dropzone__image-instructions--hidden <?php endif; ?>">
 										<?php esc_html_e( 'Click or drag a photo above', 'community-portal' ); ?>
@@ -131,7 +132,7 @@ else :
 								</div>
 								<button class="dz-remove
 								<?php
-								if ( ! isset( $community_fields['image_url'] ) || strlen( $community_fields['image_url'] ) === 0 ) :
+								if ( ! isset( $community_fields['image_url'] ) || isset( $community_fields['image_url'] ) && 0 === strlen( $community_fields['image_url'] ) ) :
 									?>
 									dz-remove--hide<?php endif; ?>" type="button" data-dz-remove="" ><?php esc_html_e( 'Remove file', 'community-portal' ); ?></button>
 							</div>

--- a/js/dropzone.js
+++ b/js/dropzone.js
@@ -43,6 +43,7 @@ jQuery(function() {
 				jQuery('#dropzone-photo-uploader').addClass("dropzone__image-upload--complete");
 				jQuery('.form__error--image').parent().removeClass('form__error-container--visible');
 				jQuery('.dz-remove').removeClass('dz-remove--hide');
+				jQuery('.dz-remove').css('display', 'block');
 				jQuery('.dropzone__image-instructions').addClass('dropzone__image-instructions--hidden');
 				if (jQuery('#image-delete')) {
 					jQuery('#image-delete').removeClass('hidden');


### PR DESCRIPTION
This PR is in regards to this https://github.com/mozilla/community-portal/issues/539 issue.
 
I was able to reproduce the error once.  Made a couple changes and cannot reproduce the error anymore.  But please test locally one with a profile image already set and one without one set the first time.  I used unset( $community_fields['image_url'] ); to simulate not having their profile image set.  I think I've corrected the issue but please test and let me know your results