### PR TITLE
Feature/security  fix group export

### DIFF
--- a/lib/activities.php
+++ b/lib/activities.php
@@ -31,7 +31,7 @@ function mozilla_download_activity_events() {
 
 		foreach ( $events as $event ) {
 			$event_meta = get_post_meta( $event->post_id, 'event-meta' );
-			if ( isset( $event_meta[0]->initiative ) && intval( $event_meta[0]->initiative ) === $activity->ID ) {
+			if ( isset( $event_meta[0]->initiative ) && intval( $event_meta[0]->initiative ) === intval( $activity->ID ) ) {
 				$event->meta      = $event_meta[0];
 				$related_events[] = $event;
 			}
@@ -78,7 +78,7 @@ function mozilla_download_activity_events() {
 			if ( $location_object->country ) {
 				$address = $address . ' ' . $countries[ $location_object->country ];
 			}
-
+			
 			$location     = 'OE' === $location->country ? 'Online' : $address;
 			$group_object = new BP_Groups_Group( $related_event->group_id );
 			$group        = ( $group_object->id ) ? $group_object->name : 'N/A';

--- a/lib/campaigns.php
+++ b/lib/campaigns.php
@@ -220,7 +220,7 @@ function mozilla_download_campaign_events() {
 
 		foreach ( $events as $event ) {
 			$event_meta = get_post_meta( $event->post_id, 'event-meta' );
-			if ( isset( $event_meta[0]->initiative ) && intval( $event_meta[0]->initiative ) === $campaign->ID ) {
+			if ( isset( $event_meta[0]->initiative ) && intval( $event_meta[0]->initiative ) === intval( $campaign->ID ) ) {
 				$event->meta      = $event_meta[0];
 				$related_events[] = $event;
 			}

--- a/lib/groups.php
+++ b/lib/groups.php
@@ -728,7 +728,8 @@ function mozilla_download_group_events() {
 		$related_events = array();
 
 		foreach ( $events as $event ) {
-			if ( strlen( $event->group_id ) > 0 && $event->group_id === $group->id ) {
+
+			if ( strlen( $event->group_id ) > 0 && intval( $event->group_id ) === intval( $group->id ) ) {
 				$related_events[] = $event;
 			}
 		}
@@ -759,22 +760,35 @@ function mozilla_download_group_events() {
 			}
 
 			// Remove last comma.
-			$tags = rtrim( $tags, ', ' );
+			$tags    = rtrim( $tags, ', ' );
+			$address = '';
 
-			$address = $location_object->address;
-			if ( $location_object->city ) {
-				$address = $address . ' ' . $location_object->city;
+			if ( 'OE' === strtoupper( $location_object->country ) ) {
+				$address = $location_object->location_name;
+			} else {
+
+				if ( $location_object->location_name ) {
+					$address = $location_object->location_name;
+				}
+
+				if ( $location_object->address ) {
+					$address = $address . ', ' . $location_object->address;
+				}
+
+				if ( $location_object->city ) {
+					$address = $address . ', ' . $location_object->city;
+				}
+
+				if ( $location_object->town ) {
+					$address = $address . ', ' . $location_object->town;
+				}
+
+				if ( $location_object->country ) {
+					$address = $address . ', ' . $countries[ $location_object->country ];
+				}
 			}
 
-			if ( $location_object->town ) {
-				$address = $address . ' ' . $location_object->town;
-			}
-
-			if ( $location_object->country ) {
-				$address = $address . ' ' . $countries[ $location_object->country ];
-			}
-
-			$location     = 'OE' === $location->country ? 'Online' : $address;
+			$location     = $address;
 			$group_object = new BP_Groups_Group( $related_event->group_id );
 			$group        = ( $group_object->id ) ? $group_object->name : 'N/A';
 
@@ -799,6 +813,7 @@ function mozilla_download_group_events() {
 			fputcsv( $out, $row );
 
 		}
+
 		fclose( $out );
 	}
 


### PR DESCRIPTION
This fixes a bug in that was causing the events export for events to be empty.  The fix is essentially cause by the ===.  I have casted both sides of the conditional statement to be integers .  I have also fixed other exports where this type of error can occur.