### PR TITLE
Menu translations

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -52,25 +52,25 @@
 					<img src="<?php echo esc_attr( get_stylesheet_directory_uri() ); ?>/images/footer-logo.png"  class="footer__logo" alt="><?php echo esc_attr_e( 'Mozilla Logo', 'community-portal' ); ?>" />
 				</div>
 				<div class="footer__menu-container">
-					<?php if( $current_translation ): ?>
+					<?php if ( $current_translation ) : ?>
 						<?php
 						wp_nav_menu(
 							array(
-								'menu'       => 'Footer Primary - '.$current_translation,
+								'menu'       => 'Footer Primary - ' . $current_translation,
 								'menu_class' => 'footer-menu footer-menu--primary',
 							)
 						);
 						?>
-					<?php
+						<?php
 						wp_nav_menu(
 							array(
-								'menu'       => 'Mozilla Main Menu - '.$current_translation,
+								'menu'       => 'Mozilla Main Menu - ' . $current_translation,
 								'menu_class' => 'footer-nav-menu',
 							)
 						);
 						?>
-					<?php else: ?>
-					<?php
+					<?php else : ?>
+						<?php
 						wp_nav_menu(
 							array(
 								'menu'       => 'Footer Primary',
@@ -78,7 +78,7 @@
 							)
 						);
 						?>
-					<?php
+						<?php
 						wp_nav_menu(
 							array(
 								'menu'       => 'Mozilla Main Menu',
@@ -89,25 +89,25 @@
 					<?php endif; ?>
 					<div class="footer__mozilla-container">
 						<span class="footer__menu-title"><?php echo esc_html_e( 'Mozilla', 'community-portal' ); ?></span>
-						<?php if( $current_translation ): ?>
-						<?php
-						wp_nav_menu(
-							array(
-								'menu'       => 'Mozilla - '.$current_translation,
-								'menu_class' => 'footer-mozilla-menu',
-							)
-						);
-						?>
-						<?php else: ?>
-					<?php
+						<?php if ( $current_translation ) : ?>
+							<?php
+							wp_nav_menu(
+								array(
+									'menu'       => 'Mozilla - ' . $current_translation,
+									'menu_class' => 'footer-mozilla-menu',
+								)
+							);
+							?>
+						<?php else : ?>
+							<?php
 
-						wp_nav_menu(
-							array(
-								'menu'       => 'Mozilla',
-								'menu_class' => 'footer-mozilla-menu',
-							)
-						);
-						?>
+							wp_nav_menu(
+								array(
+									'menu'       => 'Mozilla',
+									'menu_class' => 'footer-mozilla-menu',
+								)
+							);
+							?>
 						<?php endif; ?>
 					</div>
 				</div>
@@ -117,17 +117,17 @@
 						<a href="#" class="footer__link"><?php echo esc_html_e( ' Creative Commons license.', 'community-portal' ); ?></a>
 					</p>
 					<div class="footer__menu-legal-container">
-						<?php if( $current_translation ): ?>
+						<?php if ( $current_translation ) : ?>
 							<?php
 							wp_nav_menu(
 								array(
-									'menu'       => 'Legal - '.$current_translation,
+									'menu'       => 'Legal - ' . $current_translation,
 									'menu_class' => 'footer-legal-menu',
 								)
 							);
 							?>
-						<?php else: ?>
-						<?php
+						<?php else : ?>
+							<?php
 							wp_nav_menu(
 								array(
 									'menu'       => 'Legal',

--- a/footer.php
+++ b/footer.php
@@ -11,6 +11,9 @@
  */
 
 ?>
+<?php
+	$current_translation = mozilla_get_current_translation();
+?>
 		<footer class="footer">
 			<?php
 			if ( ! isset( $_COOKIE['gdpr'] ) ) {
@@ -49,6 +52,24 @@
 					<img src="<?php echo esc_attr( get_stylesheet_directory_uri() ); ?>/images/footer-logo.png"  class="footer__logo" alt="><?php echo esc_attr_e( 'Mozilla Logo', 'community-portal' ); ?>" />
 				</div>
 				<div class="footer__menu-container">
+					<?php if( $current_translation ): ?>
+						<?php
+						wp_nav_menu(
+							array(
+								'menu'       => 'Footer Primary - '.$current_translation,
+								'menu_class' => 'footer-menu footer-menu--primary',
+							)
+						);
+						?>
+					<?php
+						wp_nav_menu(
+							array(
+								'menu'       => 'Mozilla Main Menu - '.$current_translation,
+								'menu_class' => 'footer-nav-menu',
+							)
+						);
+						?>
+					<?php else: ?>
 					<?php
 						wp_nav_menu(
 							array(
@@ -65,9 +86,19 @@
 							)
 						);
 						?>
-
+					<?php endif; ?>
 					<div class="footer__mozilla-container">
 						<span class="footer__menu-title"><?php echo esc_html_e( 'Mozilla', 'community-portal' ); ?></span>
+						<?php if( $current_translation ): ?>
+						<?php
+						wp_nav_menu(
+							array(
+								'menu'       => 'Mozilla - '.$current_translation,
+								'menu_class' => 'footer-mozilla-menu',
+							)
+						);
+						?>
+						<?php else: ?>
 					<?php
 
 						wp_nav_menu(
@@ -77,6 +108,7 @@
 							)
 						);
 						?>
+						<?php endif; ?>
 					</div>
 				</div>
 				<div class="footer__menu-bottom-container">
@@ -85,6 +117,16 @@
 						<a href="#" class="footer__link"><?php echo esc_html_e( ' Creative Commons license.', 'community-portal' ); ?></a>
 					</p>
 					<div class="footer__menu-legal-container">
+						<?php if( $current_translation ): ?>
+							<?php
+							wp_nav_menu(
+								array(
+									'menu'       => 'Legal - '.$current_translation,
+									'menu_class' => 'footer-legal-menu',
+								)
+							);
+							?>
+						<?php else: ?>
 						<?php
 							wp_nav_menu(
 								array(
@@ -92,8 +134,9 @@
 									'menu_class' => 'footer-legal-menu',
 								)
 							);
-							$options = wp_load_alloptions();
 							?>
+						<?php endif; ?>
+						<?php $options = wp_load_alloptions(); ?>
 						<div class="footer__menu-svg-container">
 							<?php
 								$discourse_link = ( isset( $options['community_discourse'] ) && strlen( $options['community_discourse'] ) > 0 ) ? $options['community_discourse'] : '#';

--- a/header.php
+++ b/header.php
@@ -12,6 +12,7 @@
 
 $user = wp_get_current_user()->data;
 $meta = get_user_meta( $user->ID );
+$current_translation = mozilla_get_current_translation();
 
 $community_fields = isset( $meta['community-meta-fields'][0] ) ? unserialize( $meta['community-meta-fields'][0] ) : array();
 
@@ -193,6 +194,18 @@ if (
 			</div>
 			<div class="nav__menu">
 				<div class="nav__container">
+					<?php if( $current_translation ): ?>
+					<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'mozilla-theme-menu',
+								'menu_id'        => 'Mozilla Main Menu - '.$current_translation,
+								'menu_class'     => 'menu',
+							)
+						);
+						?>
+
+					<?php else: ?>
 					<?php
 						wp_nav_menu(
 							array(
@@ -202,6 +215,7 @@ if (
 							)
 						);
 						?>
+					<?php endif; ?>
 				</div>
 			</div>
 		</nav>
@@ -260,12 +274,16 @@ if (
 					</label>
 
 					<?php
-						$items = wp_get_nav_menu_items( 'Mozilla Main Menu' );
+						if( $current_translation ) {
+							$items = wp_get_nav_menu_items( 'Mozilla Main Menu - '.$current_translation );
+						} else {
+							$items = wp_get_nav_menu_items( 'Mozilla Main Menu' );
+						}
 					?>
 					<div class="nav__menu-container">
 						<div class="nav__user-container">
 						<?php if ( is_user_logged_in() ) : ?>
-							<a href="/people/<?php echo esc_attr( $user->user_nicename ); ?>" class="nav__avatar-link">
+								<a href="<?php if( $current_translation ): ?><?php echo '/'.esc_attr( $current_translation ); ?><?php endif; ?>/people/<?php echo esc_attr( $user->user_nicename ); ?>" class="nav__avatar-link">
 								<div class="nav__avatar
 								<?php
 								if ( ! $avatar ) :

--- a/header.php
+++ b/header.php
@@ -10,8 +10,8 @@
  * @author  Playground Inc.
  */
 
-$user = wp_get_current_user()->data;
-$meta = get_user_meta( $user->ID );
+$user                = wp_get_current_user()->data;
+$meta                = get_user_meta( $user->ID );
 $current_translation = mozilla_get_current_translation();
 
 $community_fields = isset( $meta['community-meta-fields'][0] ) ? unserialize( $meta['community-meta-fields'][0] ) : array();
@@ -194,19 +194,19 @@ if (
 			</div>
 			<div class="nav__menu">
 				<div class="nav__container">
-					<?php if( $current_translation ): ?>
-					<?php
+					<?php if ( $current_translation ) : ?>
+						<?php
 						wp_nav_menu(
 							array(
 								'theme_location' => 'mozilla-theme-menu',
-								'menu_id'        => 'Mozilla Main Menu - '.$current_translation,
+								'menu_id'        => 'Mozilla Main Menu - ' . $current_translation,
 								'menu_class'     => 'menu',
 							)
 						);
 						?>
 
-					<?php else: ?>
-					<?php
+					<?php else : ?>
+						<?php
 						wp_nav_menu(
 							array(
 								'theme_location' => 'mozilla-theme-menu',
@@ -274,16 +274,20 @@ if (
 					</label>
 
 					<?php
-						if( $current_translation ) {
-							$items = wp_get_nav_menu_items( 'Mozilla Main Menu - '.$current_translation );
-						} else {
-							$items = wp_get_nav_menu_items( 'Mozilla Main Menu' );
-						}
+					if ( $current_translation ) {
+						$items = wp_get_nav_menu_items( 'Mozilla Main Menu - ' . $current_translation );
+					} else {
+						$items = wp_get_nav_menu_items( 'Mozilla Main Menu' );
+					}
 					?>
 					<div class="nav__menu-container">
 						<div class="nav__user-container">
 						<?php if ( is_user_logged_in() ) : ?>
-								<a href="<?php if( $current_translation ): ?><?php echo '/'.esc_attr( $current_translation ); ?><?php endif; ?>/people/<?php echo esc_attr( $user->user_nicename ); ?>" class="nav__avatar-link">
+								<a href="
+								<?php
+								if ( $current_translation ) :
+									?>
+									<?php echo '/' . esc_attr( $current_translation ); ?><?php endif; ?>/people/<?php echo esc_attr( $user->user_nicename ); ?>" class="nav__avatar-link">
 								<div class="nav__avatar
 								<?php
 								if ( ! $avatar ) :


### PR DESCRIPTION
Handles menu translations.  There are some settings that you will need to modify to create the translations.

First you will need to use WPML's menu sync functionality found below

<img width="1654" alt="Screen Shot 2020-06-10 at 3 12 49 PM" src="https://user-images.githubusercontent.com/2521244/84308657-e1988000-ab2c-11ea-99fc-4d5700802bfe.png">

Use the button at the bottom of the page and sync the menus.

Next you will have to rename the translated menus and update the copy and links for the items.  To do this you will go to the Wordpress Appearance Menus section of the admin.

<img width="1661" alt="Screen Shot 2020-06-10 at 3 13 56 PM" src="https://user-images.githubusercontent.com/2521244/84308783-1efd0d80-ab2d-11ea-8d96-6bd23a01c025.png">

Then you will need to rename the translated versions.  The name of the translated menus should be the original name with - LANGUAGE CODE appended to the end.  As an example the Spanish version of the Mozilla Main Menu would be Mozilla Main Menu - es.  Then you would need to update the URLs to go to the specific translated URLs.  
