### PR TITLE
Fixed discourse value not displaying in form

### DIFF
--- a/buddypress/members/single/edit.php
+++ b/buddypress/members/single/edit.php
@@ -487,13 +487,14 @@ else :
 						$discourse_value = $form['discourse'];
 					} else {
 						if ( is_array( $community_fields ) && isset( $community_fields['discourse'] ) ) {
+							
 							$discourse_value = $community_fields['discourse'];
 						} else {
 							$discourse_value = '';
 						}
 					}
 					?>
-					<input type="text" name="discourse" id="discourse" class="profile__input" value="<?php esc_attr( $discourse_value ); ?>"/>
+					<input type="text" name="discourse" id="discourse" class="profile__input" value="<?php echo esc_attr( $discourse_value ); ?>"/>
 				</div>
 				<div class="profile__select-container">
 					<label class="profile__label" for="profile-discourse-visibility"><?php esc_html_e( 'Can be viewed by', 'community-portal' ); ?></label>


### PR DESCRIPTION
Fixed a bug where the value for discourse being stored wasn't being printed to the input field in the edit profile form


