### PR TITLE
Fix/button wrap

### DIFF
--- a/scss/_campaign.scss
+++ b/scss/_campaign.scss
@@ -242,6 +242,7 @@
         color: $color-gray-secondary;
         display: flex;
         flex-direction: row;
+        flex-wrap: wrap;
         font-size: remCalc(14);
         height: 100%;
         line-height: 20px;

--- a/scss/_campaign.scss
+++ b/scss/_campaign.scss
@@ -278,10 +278,7 @@
         text-decoration: none;
         transition: background-color 0.2s ease-in;
         width: auto;
-
-        @include tablet-and-up {
-            max-width: 300px;
-        }
+        max-width: 300px;
 
         &:first-child:last-child {
           margin-left: auto;

--- a/scss/_campaign.scss
+++ b/scss/_campaign.scss
@@ -270,7 +270,6 @@
         font-size: remCalc(14);
         height: auto;
         line-height: 22px;
-        max-width: 200px;
         min-width: 160px;
         padding: 15px 33px;
         padding-left: 55px;
@@ -279,6 +278,10 @@
         text-decoration: none;
         transition: background-color 0.2s ease-in;
         width: auto;
+
+        @include tablet-and-up {
+            max-width: 300px;
+        }
 
         &:first-child:last-child {
           margin-left: auto;

--- a/scss/_group.scss
+++ b/scss/_group.scss
@@ -508,7 +508,7 @@
         border-radius: 28px;
         color: $color-blue-50;
         font-size: remCalc(16);
-        height: 48px;
+        min-height: 48px;
         line-height: 18px;
         min-width: 160px;
         padding: 15px 33px;
@@ -517,7 +517,6 @@
         text-align: center;
         text-decoration: none;
         transition: background-color 0.2s ease-in;
-        width: 188px;
 
         &:focus,
         &:hover {
@@ -532,9 +531,8 @@
             }
         }
 
-
         @include tablet-and-up {
-            width: 188px;
+            max-width: 300px;
         }
 
         svg {

--- a/scss/_group.scss
+++ b/scss/_group.scss
@@ -517,6 +517,7 @@
         text-align: center;
         text-decoration: none;
         transition: background-color 0.2s ease-in;
+        max-width: 300px;
 
         &:focus,
         &:hover {
@@ -529,10 +530,6 @@
                     stroke: $color-white;
                 }
             }
-        }
-
-        @include tablet-and-up {
-            max-width: 300px;
         }
 
         svg {


### PR DESCRIPTION
Fixes issues with text overflowing buttons for Groups and Campaigns

**BEFORE**

<img width="910" alt="Screen Shot 2020-06-23 at 2 25 50 PM" src="https://user-images.githubusercontent.com/10262636/85781220-75ed1000-b6f3-11ea-9252-b1f8ed4c18fc.png">

**AFTER**

<img width="647" alt="Screen Shot 2020-06-25 at 2 16 54 PM" src="https://user-images.githubusercontent.com/10262636/85781304-8a310d00-b6f3-11ea-8517-3ae3149e4732.png">

<img width="739" alt="Screen Shot 2020-06-25 at 2 18 54 PM" src="https://user-images.githubusercontent.com/10262636/85781256-7d141e00-b6f3-11ea-86af-abeaefd29d38.png">
