### PR TITLE
Update 3up container so that background colour is full width

### DIFF
--- a/scss/_campaign.scss
+++ b/scss/_campaign.scss
@@ -417,22 +417,21 @@
     &__3up-text-block {
         background-color: $color-white;
         width: 100%;
-        max-width: 1440px;
-        margin: 0 auto;
-
-        padding: 64px $mobile-padding;
-
-        @include tablet-and-up {
-            padding: 64px $tablet-padding;    
-        }
-    
-        @include desktop-and-up {
-            padding: 64px $desktop-padding;
-        }
 
         .campaign__block-container {
-            max-width: none;
-        }
+			max-width: 1440px;
+			margin: 0 auto;
+
+			padding: 64px $mobile-padding;
+
+			@include tablet-and-up {
+				padding: 64px $tablet-padding;    
+			}
+		
+			@include desktop-and-up {
+				padding: 64px $desktop-padding;
+			}
+		}
 
         &.campaign__3up-text-block--grey {
             background-color: $color-gray-background;


### PR DESCRIPTION
Currently 3-up columns on Campaign pages with white backgrounds have grey overflow, this updates the styles so that the 3up columns with white backgrounds go full width, removing the grey overflow. 
<img width="1673" alt="Screen Shot 2020-06-30 at 12 37 57 PM" src="https://user-images.githubusercontent.com/38357500/86152693-91c72c00-bace-11ea-99c1-61cfa6260573.png">
