### PR TITLE
Sanitize discourse category

### DIFF
--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -1359,7 +1359,9 @@
 
 							if ( isset( $options['discourse_url'] ) && strlen( $options['discourse_url'] ) > 0 ) {
 								$discourse_api_url = rtrim( $options['discourse_url'], '/' );
-								$api_url           = "{$options['discourse_url']}/c/{$discourse_group['discourse_category_id']}";
+								
+								$discourse_category_id = intval( trim( $discourse_group['discourse_category_id'] ) );
+								$api_url           = "{$options['discourse_url']}/c/{$discourse_category_id}";
 
 								$topics = mozilla_discourse_get_category_topics( $api_url );
 								$topics = array_slice( $topics, 0, 4 );


### PR DESCRIPTION
This bug fix tries to address this bug https://github.com/mozilla/community-portal/issues/415

Ruben suggests we try to use the format  https://discourse.mozilla.org/c/<DISCOURSE_GROUP_ID>.json to get topics for the specified group.  This is how we've been handling this request but for some reason the sumo and reps groups aren't fetching topics.  

Since this is something strictly related to production it's been hard to debug or test.  I've looked at the meta data associated with the two groups and made the calls manually on my local environment by going to the mozilla theme settings and changing the mozilla discourse URL to the production value of https://discourse.mozilla.org.  Then going into the <THEME_ROOT>/buddypress/groups/single/group.php file and manually assigning the variable ```$discourse_group['discourse_category_id']``` on line ~1362 (exact line may vary)  to the value 9 which is the discourse group id for the reps group on production.  Then when i view any group page on my local the topics get displayed as shown below.

<img width="961" alt="Screen Shot 2020-07-16 at 10 47 03 AM" src="https://user-images.githubusercontent.com/2521244/87685735-bae3ef80-c751-11ea-9778-bc89357ae70e.png">

This lead me to believe that perhaps the value being stored perhaps has spaces or some characters we can't see that is causing this to fail on production.  I've added a intval and trim functions on the ```$discourse_group['discourse_category_id']``` variable to cover this case, we won't be able to fully test this until it's live on production.  Other than this I'm not sure what else the issue can be as all other pages are working fine when pulling topics from discourse and Mozilla will have to do their own debugging to remedy this issue.

 



