### PR TITLE
Add filter to remove inactive tag values from groups

### DIFF
--- a/buddypress/groups/index-directory.php
+++ b/buddypress/groups/index-directory.php
@@ -364,6 +364,7 @@
 					<label class="groups__label"><?php esc_html_e( 'Tag', 'community-portal' ); ?></label>
 					<select class="groups__tag-select">
 						<option value=""><?php esc_html_e( 'All', 'community-portal' ); ?></option>
+
 						<?php foreach ( $tags as $loop_tag ) : ?>
 							<?php
 							if ( false !== stripos( $loop_tag->slug, '_' ) ) {
@@ -460,10 +461,11 @@
 								<div class="groups__card-tags">
 									<?php
 										$tag_counter = 0;
+										$group_tags = array_unique( array_filter( $meta['group_tags'], 'mozilla_filter_inactive_tags'));
 									?>
 									<?php if ( isset( $meta['group_tags'] ) && is_array( $meta['group_tags'] ) ) : ?>
 									<ul class="groups__card-tags__container">
-										<?php foreach ( array_unique( $meta['group_tags'] ) as $key => $value ) : ?>
+										<?php foreach ( $group_tags as $key => $value ) : ?>
 											<?php
 
 											$system_tag = array_values(
@@ -479,8 +481,8 @@
 										<li class="groups__tag"><?php echo esc_html( $system_tag[0]->name ); ?></li>
 												<?php $tag_counter++; ?>
 										<?php endif; ?>
-											<?php if ( 2 === $tag_counter && count( $meta['group_tags'] ) > 2 ) : ?>
-										<li class="groups__tag">+ <?php echo esc_html( count( $meta['group_tags'] ) - 2 ); ?> <?php esc_html_e( ' more tags', 'community-portal' ); ?></li>
+											<?php if ( 2 === $tag_counter && count( $group_tags ) > 2 ) : ?>
+										<li class="groups__tag">+ <?php echo esc_html( count( $group_tags )  - 2 ); ?> <?php esc_html_e( ' more tags', 'community-portal' ); ?></li>
 												<?php break; ?>
 										<?php endif; ?>
 									<?php endforeach; ?>

--- a/buddypress/groups/single/edit.php
+++ b/buddypress/groups/single/edit.php
@@ -58,7 +58,6 @@ if ( ! empty( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHO
 }
 
 $form_tags = isset( $form['tags'] ) && is_array( $form['tags'] ) ? array_unique( array_filter( array_map( 'mozilla_map_tags', $form['tags'] ), 'strlen' ) ) : array();
-
 ?>
 <div class="content">
 	<div class="create-group">

--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -1577,13 +1577,13 @@
 							</div>
 						</div>
 						<?php endif; ?>
-						<?php if ( isset( $group_meta['group_tags'] ) && count( array_unique( $group_meta['group_tags'] ) ) > 0 ) : ?>
+						<?php $group_tags = isset($group_meta['group_tags']) ? array_unique( array_filter( $group_meta['group_tags'], 'mozilla_filter_inactive_tags')) : false; ?>
+						<?php if ( isset( $group_tags ) && count( $group_tags ) > 0 ) : ?>
 						<div class="group__card">
 							<div class="group__card-content group__card-content--small">
 								<span><?php esc_html_e( 'Tags', 'community-portal' ); ?></span>
 								<div class="group__tags">
-									<?php $post_tags = array_unique( array_filter( $group_meta['group_tags'], 'mozilla_filter_inactive_tags'))?>
-									<?php foreach ( $post_tags as $tag_loop ) : ?>
+									<?php foreach ( $group_tags as $tag_loop ) : ?>
 										
 										<?php
 										foreach ( $tags as $t ) {

--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -1582,7 +1582,9 @@
 							<div class="group__card-content group__card-content--small">
 								<span><?php esc_html_e( 'Tags', 'community-portal' ); ?></span>
 								<div class="group__tags">
-									<?php foreach ( array_unique( $group_meta['group_tags'] ) as $tag_loop ) : ?>
+									<?php $post_tags = array_unique( array_filter( $group_meta['group_tags'], 'mozilla_filter_inactive_tags'))?>
+									<?php foreach ( $post_tags as $tag_loop ) : ?>
+										
 										<?php
 										foreach ( $tags as $t ) {
 											$found = false;

--- a/front-page.php
+++ b/front-page.php
@@ -238,10 +238,12 @@
 										<?php
 												$tag_counter = 0;
 										if ( isset( $meta ) && isset( $meta['group_tags'] ) ) :
+											$group_tags = array_unique( array_filter( $meta['group_tags'], 'mozilla_filter_inactive_tags'));
+
 											?>
 										<ul class="groups__card-tags__container">
 											<?php
-											foreach ( $meta['group_tags'] as $key => $value ) :
+											foreach ( $group_tags as $key => $value ) :
 												$tag_value = false;
 												if ( 'en' !== $current_translation ) {
 													$tag_value = get_term_by( 'slug', $value . '_' . $current_translation, 'post_tag' );
@@ -253,8 +255,8 @@
 													?>
 												<li class="groups__tag"><?php echo esc_html( $tag_value->name ); ?></li>
 													<?php $tag_counter++; ?>
-													<?php if ( 2 === $tag_counter && count( $meta['group_tags'] ) > 2 ) : ?>
-													<li class="groups__tag">+ <?php echo esc_html( count( $meta['group_tags'] ) - 2 ); ?> <?php echo esc_html_e( ' more tags', 'community-portal' ); ?></li>
+													<?php if ( 2 === $tag_counter && count( $group_tags ) > 2 ) : ?>
+													<li class="groups__tag">+ <?php echo esc_html( count( $group_tags ) - 2 ); ?> <?php echo esc_html_e( ' more tags', 'community-portal' ); ?></li>
 														<?php break; ?>
 												<?php endif; ?>
 											<?php endif; ?>

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -1026,14 +1026,24 @@ function mozilla_localize_date( $date, $format ) {
  * @param string $tag the saved tag.
  */
 function mozilla_map_tags( $tag ) {
-	$term_obj = get_term_by( 'name', $tag, 'post_tag' );
+	$term_obj = get_term_by( 'slug', $tag, 'post_tag' );
 	if ( is_object( $term_obj ) && ! empty( $term_obj ) && isset( $term_obj->slug ) && strlen( $term_obj->slug ) > 0 ) {
 		if ( false !== stripos( $term_obj->slug, '_' ) ) {
 			$term_obj->slug = substr( $term_obj->slug, 0, stripos( $term_obj->slug, '_' ) );
 		};
 		return $term_obj->slug;
 	}
-	return $tag;
+	return '';
+}
+
+/**
+ * Filters tags for active tags
+ *
+ * @param string $tag the saved tag.
+ */
+function mozilla_filter_inactive_tags( $tag ) {
+	$term_obj = get_term_by( 'slug', $tag, 'post_tag' );
+	return is_object( $term_obj ) && ! empty( $term_obj ) && isset( $term_obj->slug ) && strlen( $term_obj->slug ) > 0;
 }
 
 /**


### PR DESCRIPTION
This PR will fix the bug reported in the Mozilla-MDM channel by Francesca regarding duplicate tags on groups. 

The bug was caused because values for tags that were no longer active were still attached to the group. This fix will: 

- Filter out inactive tags on the single group page
- Filter out inactive tags on the group edit page
- Filter out inactive tags on the groups directory page (including total count)
- Filter out inactive tags on the homepage for featured groups (including total count)

To test, delete a tag that is applied to an active group and check that it does not display in any of these places. 