### PR TITLE
Linking activities, campaigns and events

### DIFF
--- a/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
+++ b/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
@@ -43,6 +43,11 @@
 			<?php if ( $initiative ) : ?>
 				<?php
 					$c = get_post( $initiative );
+					if ('en' !== $current_translation ) {
+						$translated_initiative = apply_filters( 'wpml_object_id', $c->ID, $c->post_type, true, $current_translation );
+						$translated_title = get_the_title($translated_initiative);
+						$c->post_title = isset($translated_title) && strlen($translated_title) > 0 ? $translated_title : $c->post_title;
+					}
 					if (!empty($c)):
 				?>
 						<div class="col-lg-12 col-md-6 col-sm-12">

--- a/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
+++ b/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
@@ -43,23 +43,25 @@
 			<?php if ( $initiative ) : ?>
 				<?php
 					$c = get_post( $initiative );
-					if ('en' !== $current_translation ) {
-						$translated_initiative = apply_filters( 'wpml_object_id', $c->ID, $c->post_type, true, $current_translation );
-						$translated_title = get_the_title($translated_initiative);
-						$c->post_title = isset($translated_title) && strlen($translated_title) > 0 ? $translated_title : $c->post_title;
-					}
-					if (!empty($c)):
-				?>
+				if ( 'en' !== $current_translation ) {
+					$translated_initiative = apply_filters( 'wpml_object_id', $c->ID, $c->post_type, true, $current_translation );
+					$translated_title      = get_the_title( $translated_initiative );
+					$c->post_title         = isset( $translated_title ) && strlen( $translated_title ) > 0 ? $translated_title : $c->post_title;
+				}
+				if ( ! empty( $c ) ) :
+					?>
 						<div class="col-lg-12 col-md-6 col-sm-12">
 							<p class="events-single__label"><?php esc_html_e( 'Part of', 'community-portal' ); ?></p>
 							<a 
-								href="<?php
-									if ( 'campaign' === $c->post_type ) :
-										echo esc_attr( get_home_url( null, 'campaigns/' . $c->post_name ) );
+								href="
+								<?php
+								if ( 'campaign' === $c->post_type ) :
+									echo esc_attr( get_home_url( null, 'campaigns/' . $c->post_name ) );
 									else :
 										echo esc_attr( get_home_url( null, 'activities/' . $c->post_name ) );
 									endif;
-									?>" 
+									?>
+									" 
 								class="events-single__externam-link events-single__externam-link--icon">
 							<?php if ( 'campaign' === $c->post_type ) : ?>
 							<svg width="27" height="28" viewBox="0 0 27 28" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/plugins/events-manager/templates/template-parts/events-filters.php
+++ b/plugins/events-manager/templates/template-parts/events-filters.php
@@ -21,15 +21,15 @@
 	$ddm_countries  = array();
 	$used_languages = array();
 	$filter_events  = EM_Events::get( array( 'scope' => 'all' ) );
-	$online_event = __('Online Event', 'community-portal');
+	$online_event   = __( 'Online Event', 'community-portal' );
 
 foreach ( $filter_events as $e ) {
 	$location     = em_get_location( $e->location_id );
 	$country_code = $location->location_country;
 
 	if ( strlen( $country_code ) > 0 && ! in_array( $country_code, $ddm_countries, true ) ) {
-		if ('OE' === $country_code ) {
-			$ddm_countries[$country_code] = $online_event;
+		if ( 'OE' === $country_code ) {
+			$ddm_countries[ $country_code ] = $online_event;
 		} else {
 			$ddm_countries[ $country_code ] = $countries[ $country_code ];
 		}
@@ -99,13 +99,13 @@ if ( count( $categories ) > 0 ) {
 				$campaign_status = get_field( 'campaign_status', $campaign->ID );
 
 				if ( strtolower( $campaign_status ) !== 'closed' ) {
-					$campaign_id = apply_filters( 'wpml_object_id', $campaign->ID, 'campaign', true, 'en' );
+					$campaign_id                 = apply_filters( 'wpml_object_id', $campaign->ID, 'campaign', true, 'en' );
 					$initiatives[ $campaign_id ] = $campaign->post_title;
 					continue;
 				}
 
 				if ( $today >= $start && $today <= $end ) {
-					$campaign_id = apply_filters( 'wpml_object_id', $campaign->ID, 'campaign', true, 'en' );
+					$campaign_id                 = apply_filters( 'wpml_object_id', $campaign->ID, 'campaign', true, 'en' );
 					$initiatives[ $campaign_id ] = $campaign->post_title;
 				}
 			}
@@ -117,7 +117,7 @@ if ( count( $categories ) > 0 ) {
 
 			$activities = new WP_Query( $args );
 			foreach ( $activities->posts as $activity ) {
-				$activity_id = apply_filters( 'wpml_object_id', $activity->ID, 'activity', true, 'en' );
+				$activity_id                 = apply_filters( 'wpml_object_id', $activity->ID, 'activity', true, 'en' );
 				$initiatives[ $activity_id ] = $activity->post_title;
 			}
 

--- a/plugins/events-manager/templates/template-parts/single-event-card.php
+++ b/plugins/events-manager/templates/template-parts/single-event-card.php
@@ -102,6 +102,11 @@
 				<?php
 					$initiative = get_post( intval( $card_event_meta[0]->initiative ) );
 					if (!empty($initiative)): 
+					if ('en' !== $current_translation ) {
+						$translated_initiative = apply_filters( 'wpml_object_id', $initiative->ID, $initiative->post_type, true, $current_translation );
+						$translated_title = get_the_title($translated_initiative);
+						$initiative->post_title = isset($translated_title) && strlen($translated_title) > 0 ? $translated_title : $initiative->post_title;
+					}
 				?>
 							<div class="events__campaign">
 								<?php if ( 'campaign' === $initiative->post_type ) : ?>

--- a/plugins/events-manager/templates/template-parts/single-event-card.php
+++ b/plugins/events-manager/templates/template-parts/single-event-card.php
@@ -99,15 +99,15 @@
 				</div>
 				<?php endif; ?>
 				<?php if ( isset( $card_event_meta[0]->initiative ) && strlen( $card_event_meta[0]->initiative ) > 0 ) : ?>
-				<?php
+					<?php
 					$initiative = get_post( intval( $card_event_meta[0]->initiative ) );
-					if (!empty($initiative)): 
-					if ('en' !== $current_translation ) {
-						$translated_initiative = apply_filters( 'wpml_object_id', $initiative->ID, $initiative->post_type, true, $current_translation );
-						$translated_title = get_the_title($translated_initiative);
-						$initiative->post_title = isset($translated_title) && strlen($translated_title) > 0 ? $translated_title : $initiative->post_title;
-					}
-				?>
+					if ( ! empty( $initiative ) ) :
+						if ( 'en' !== $current_translation ) {
+							$translated_initiative  = apply_filters( 'wpml_object_id', $initiative->ID, $initiative->post_type, true, $current_translation );
+							$translated_title       = get_the_title( $translated_initiative );
+							$initiative->post_title = isset( $translated_title ) && strlen( $translated_title ) > 0 ? $translated_title : $initiative->post_title;
+						}
+						?>
 							<div class="events__campaign">
 								<?php if ( 'campaign' === $initiative->post_type ) : ?>
 								<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/templates/blocks/events-block.php
+++ b/templates/blocks/events-block.php
@@ -113,6 +113,11 @@ $all_countries = em_get_countries();
 								<?php if ( isset( $event_meta[0]->initiative ) && strlen( $event_meta[0]->initiative ) > 0 ) : ?>
 									<?php
 									$initiative = get_post( intval( $event_meta[0]->initiative ) );
+									if ('en' !== $current_translation ) {
+										$translated_initiative = apply_filters( 'wpml_object_id', $initiative->ID, $initiative->post_type, true, $current_translation );
+										$translated_title = get_the_title($translated_initiative);
+										$initiative->post_title = isset($translated_title) && strlen($translated_title) > 0 ? $translated_title : $initiative->post_title;
+									}
 									?>
 								<div class="campaign__campaign-events">
 									<?php if ( 'campaign' === $initiative->post_type ) : ?>

--- a/templates/blocks/events-block.php
+++ b/templates/blocks/events-block.php
@@ -113,10 +113,10 @@ $all_countries = em_get_countries();
 								<?php if ( isset( $event_meta[0]->initiative ) && strlen( $event_meta[0]->initiative ) > 0 ) : ?>
 									<?php
 									$initiative = get_post( intval( $event_meta[0]->initiative ) );
-									if ('en' !== $current_translation ) {
-										$translated_initiative = apply_filters( 'wpml_object_id', $initiative->ID, $initiative->post_type, true, $current_translation );
-										$translated_title = get_the_title($translated_initiative);
-										$initiative->post_title = isset($translated_title) && strlen($translated_title) > 0 ? $translated_title : $initiative->post_title;
+									if ( 'en' !== $current_translation ) {
+										$translated_initiative  = apply_filters( 'wpml_object_id', $initiative->ID, $initiative->post_type, true, $current_translation );
+										$translated_title       = get_the_title( $translated_initiative );
+										$initiative->post_title = isset( $translated_title ) && strlen( $translated_title ) > 0 ? $translated_title : $initiative->post_title;
 									}
 									?>
 								<div class="campaign__campaign-events">


### PR DESCRIPTION
This PR fixes the bug listed on the localization tracking spreadsheet. In a previous PR I updated the event creation/edit functionality so it was always linking events with the English translation of Activities/Campaigns, but would then link out to their translated version depending on the active language, and always using the ID of the Campaign/Activity in English for filtering. 

This PR updates the front-end rendering of events in the following places to show the translated title of the Activity or Campaign:

- Single events
- Event cards on Events listing page
- Event cards within single Groups
- Event cards on the homepage
- Event cards in the Events Block on single campaigns. 

To test, create a translation of Activity/Campaign with a translated title, connect it to an event and test that it is rendering the properly translated name in all settings. 