### PR TITLE
Update event tags to use ID rather than name

### DIFF
--- a/lib/language.php
+++ b/lib/language.php
@@ -113,10 +113,16 @@ function mozilla_add_default_language( $url, $code ) {
 function mozilla_get_translated_tag( $category ) {
 	$current_translation = mozilla_get_current_translation();
 	if ( 'en' !== $current_translation ) {
-		$translation = get_term_by( 'slug', $category->slug . '_' . $current_translation, 'post_tag' );
+    $translation = get_term_by( 'slug', $category->slug . '_' . $current_translation, 'post_tag' );
 		if ( ! empty( $translation ) ) {
-			return $translation->name;
+			return (object) [
+        'name' => $translation->name,
+        'id' => $translation->term_id,
+      ];
 		}
-	}
-	return $category->name;
+  }
+	return (object) [
+    'name' => $category->name,
+    'id' => $category->term_id,
+  ];
 }

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -494,7 +494,7 @@ function mozilla_add_query_vars_filter( $vars ) {
  * @param int $tt_id id for taxonomy.
  */
 function mozilla_create_event_category( $term_id, $tt_id ) {
-	$term = get_term( $term_id, 'post_tags' );
+	$term = get_term( $term_id, 'post_tag' );
 	if ( ! empty( $term ) && false === stripos( $term->slug, '_' ) ) {
 		wp_insert_term( $term->name, 'event-categories', array( 'slug' => $term->slug ) );
 	}
@@ -510,12 +510,11 @@ add_action( 'create_post_tag', 'mozilla_create_event_category', 10, 2 );
  * @param int $tt_id id for taxonomy.
  */
 function mozilla_update_event_category( $term_id, $tt_id ) {
-	$term     = get_term( $term_id, 'post_tags' );
+	$term     = get_term( $term_id, 'post_tag' );
 	$cat_term = get_term_by( 'slug', $term->slug, 'event-categories' );
 	if ( empty( $cat_term ) ) {
 		$cat_term = get_term_by( 'name', $term->name, 'event-categories' );
 	}
-
 	if ( ! empty( $term ) && ! empty( $cat_term ) && false === stripos( $term->slug, '_' ) ) {
 		wp_update_term(
 			$cat_term->term_id,

--- a/plugins/events-manager/forms/event/categories-public.php
+++ b/plugins/events-manager/forms/event/categories-public.php
@@ -29,7 +29,7 @@
 			?>
 
 			<?php	foreach ( $categories as $category ) : ?>
-				<?php $tag_name = mozilla_get_translated_tag( $category ); ?>
+				<?php $term_object = mozilla_get_translated_tag( $category ); ?>
 				<input 
 					name="event_categories[]" 
 					class="event-creator__checkbox" 
@@ -42,7 +42,7 @@
 					}
 					?>
 				/>
-				<label class="event-creator__tag" for="<?php echo esc_attr( $category->id ); ?>"><?php echo esc_html( $tag_name ); ?></label>
+				<label class="event-creator__tag" for="<?php echo esc_attr( $category->id ); ?>"><?php echo esc_html( $term_object->name ); ?></label>
 				<?php
 				endforeach;
 			?>

--- a/plugins/events-manager/templates/event-single.php
+++ b/plugins/events-manager/templates/event-single.php
@@ -259,7 +259,7 @@ if ( isset( $em_event->group_id ) ) {
 						<?php else : ?>
 							<p><?php echo esc_html( $location->location_town ) . esc_html( ', ' ) . esc_html( $all_countries[ $em_event->location->location_country ] ); ?></p>
 						<?php endif; ?>
-						<p><a href="<?php print esc_attr( add_query_arg( array( 'country' => $all_countries[ $em_event->location->location_country ] ), get_home_url( null, 'events' ) ) ); ?>"><?php esc_html_e( 'View more events in ', 'community-portal' ); ?><?php print esc_html( $all_countries[ $em_event->location->location_country ] ); ?></a></p>
+						<p><a href="<?php print esc_attr( add_query_arg( array( 'country' => $em_event->location->location_country ), get_home_url( null, 'events' ) ) ); ?>"><?php esc_html_e( 'View more events in ', 'community-portal' ); ?><?php print esc_html( $all_countries[ $em_event->location->location_country ] ); ?></a></p>
 					<?php else : ?>
 						<p><?php esc_html_e( 'This is an online-only event', 'community-portal' ); ?></p>
 						<?php if ( ! empty( $em_event->location->name ) && filter_var( $em_event->location->name, FILTER_VALIDATE_URL ) ) : ?>

--- a/plugins/events-manager/templates/events-list.php
+++ b/plugins/events-manager/templates/events-list.php
@@ -13,7 +13,6 @@
 ?>
 
 <?php
-	$theme_directory = get_template_directory_uri();
 	$countries = em_get_countries();
 	$current_page = isset( $_REQUEST['pno'] ) ? intval( sanitize_key( $_REQUEST['pno'] ) ) : 1;
 	$args         = apply_filters( 'em_content_events_args', $args );

--- a/plugins/events-manager/templates/events-list.php
+++ b/plugins/events-manager/templates/events-list.php
@@ -13,8 +13,11 @@
 ?>
 
 <?php
+	$theme_directory = get_template_directory_uri();
+	$countries = em_get_countries();
 	$current_page = isset( $_REQUEST['pno'] ) ? intval( sanitize_key( $_REQUEST['pno'] ) ) : 1;
 	$args         = apply_filters( 'em_content_events_args', $args );
+
 if (
 	isset( $args['search'] ) &&
 		( strpos( $args['search'], '"' ) !== false ||
@@ -52,13 +55,13 @@ switch ( strtolower( trim( $view ) ) ) {
 }
 
 if ( 'all' !== strtolower( $country ) ) {
-	$args['country'] = $country;
+	$args['country'] = $countries[ $country ];
 }
 
 if ( 'all' !== $event_tag ) {
 	$current_translation = mozilla_get_current_translation();
 	if ( $current_translation && stripos( $event_tag, '_' . $current_translation ) !== false ) {
-		$event_tag = substr( $event_tag, 0, stripos( $event_tag, '_' . $current_translation ) );
+    $event_tag = substr( $event_tag, 0, stripos( $event_tag, '_' . $current_translation ) );
 	}
 	$args['category'] = $event_tag;
 }

--- a/plugins/events-manager/templates/template-parts/event-cards.php
+++ b/plugins/events-manager/templates/template-parts/event-cards.php
@@ -25,19 +25,5 @@ if ( isset( $categories ) && is_array( $categories ) ) {
 		$categories
 	);
 }
-if ( 'all' !== $event_tag && ! $categories && '' !== $event_tag ) {
-	return;
-} elseif ( 'all' !== $event_tag && 'all' !== strtolower( $country ) && '' !== $event_tag && '' !== $country ) {
-	if ( ! in_array( strtolower( $event_tag ), $all_tags, true ) || $country !== $all_countries[ $location->country ] ) {
-		return;
-	} else {
-		include locate_template( 'plugins/events-manager/templates/template-parts/single-event-card.php', false, false );
-	}
-} elseif ( 'all' !== $event_tag && '' !== $event_tag ) {
-	include locate_template( 'plugins/events-manager/templates/template-parts/single-event-card.php', false, false );
-} elseif ( 'all' !== strtolower( $country ) && '' !== $country ) {
-	include locate_template( 'plugins/events-manager/templates/template-parts/single-event-card.php', false, false );
-} else {
-	include locate_template( 'plugins/events-manager/templates/template-parts/single-event-card.php', false, false );
-}
 
+include locate_template( 'plugins/events-manager/templates/template-parts/single-event-card.php', false, false );

--- a/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
+++ b/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
@@ -32,9 +32,9 @@
 						<?php
 						foreach ( $categories as $category ) :
 							$current_translation = mozilla_get_current_translation();
-							$tag_name            = mozilla_get_translated_tag( $category );
+							$term_object            = mozilla_get_translated_tag( $category );
 							?>
-							<li class="tag"><a class="events-single__tag-link" href="<?php print esc_attr( add_query_arg( array( 'tag' => $category->name ), get_home_url( null, 'events' ) ) ); ?>"><?php echo esc_html( $tag_name ); ?></a></li>
+							<li class="tag"><a class="events-single__tag-link" href="<?php print esc_attr( add_query_arg( array( 'tag' => $category->term_id ), get_home_url( null, 'events' ) ) ); ?>"><?php echo esc_html( $term_object->name ); ?></a></li>
 							<?php break; ?>
 						<?php endforeach; ?>
 					</ul>

--- a/plugins/events-manager/templates/template-parts/events-filters.php
+++ b/plugins/events-manager/templates/template-parts/events-filters.php
@@ -16,7 +16,6 @@
 	global $wpdb;
 	$theme_directory = get_template_directory();
 	require "{$theme_directory}/languages.php";
-
 	$countries      = em_get_countries();
 	$ddm_countries  = array();
 	$used_languages = array();
@@ -41,7 +40,6 @@ foreach ( $filter_events as $e ) {
 	}
 }
 	asort( $ddm_countries );
-
 	asort( $used_languages );
 	$used_languages = array_unique( $used_languages );
 
@@ -51,10 +49,10 @@ if ( count( $categories ) > 0 ) {
 	$current_translation = mozilla_get_current_translation();
 
 	foreach ( $categories as $category ) {
-		$tag_name                             = mozilla_get_translated_tag( $category );
+		$term_object                             = mozilla_get_translated_tag( $category );
 		$categories[ $category->id ]          = array();
-		$categories[ $category->id ]['value'] = $category->name;
-		$categories[ $category->id ]['label'] = $tag_name;
+		$categories[ $category->id ]['value'] = $term_object->id;
+		$categories[ $category->id ]['label'] = $term_object->name;
 	}
 }
 

--- a/plugins/events-manager/templates/template-parts/options.php
+++ b/plugins/events-manager/templates/template-parts/options.php
@@ -32,18 +32,18 @@
 						?>
 						selected<?php endif; ?>><?php print esc_html( $option ); ?></option>
 			<?php elseif ( 'Tag' === $field_name ) : ?>
-				<option value="<?php print esc_attr( $option['value'] ); ?>" 
+				<option value="<?php print esc_attr( $key ); ?>" 
 					<?php
-					if ( isset( $event_tag ) && strlen( $event_tag ) > 0 && strtolower( $event_tag ) === strtolower( $option['value'] ) ) :
+					if ( isset( $event_tag ) && strlen( $event_tag ) > 0 && intval( $event_tag ) === intval( $key ) ) :
 						?>
 					selected
 					<?php endif; ?> 
 					><?php print esc_html( $option['label'] ); ?></option>
 			<?php else : ?>
-				<?php if ( $option === $country ) : ?>
-				<option value="<?php echo esc_attr( $option ); ?>" selected><?php echo esc_html( $option ); ?></option>
+				<?php if ( $key === $country ) : ?>
+				<option value="<?php echo esc_attr( $key ); ?>" selected><?php echo esc_html( $option ); ?></option>
 			<?php else : ?>
-				<option value="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $option ); ?></option>
+				<option value="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $option ); ?></option>
 			<?php endif; ?>
 			<?php endif; ?>
 		<?php endforeach; ?>

--- a/plugins/events-manager/templates/template-parts/single-event-card.php
+++ b/plugins/events-manager/templates/template-parts/single-event-card.php
@@ -133,9 +133,9 @@
 			<?php if ( false !== $categories && is_array( $categories->terms ) ) : ?>
 				<?php
 				foreach ( $categories->terms as $category ) :
-					$tag_name = mozilla_get_translated_tag( $category );
+					$term_object = mozilla_get_translated_tag( $category );
 					?>
-					<li class="tag"><?php echo esc_html( $tag_name ); ?></li>
+					<li class="tag"><?php echo esc_html( $term_object->name ); ?></li>
 					<?php break; ?>
 				<?php endforeach; ?>
 			<?php endif; ?>

--- a/templates/blocks/events-block.php
+++ b/templates/blocks/events-block.php
@@ -142,9 +142,9 @@ $all_countries = em_get_countries();
 									<?php $current_translation = mozilla_get_current_translation(); ?>
 									<?php
 									foreach ( $categories->terms as $category ) :
-										$term_name = mozilla_get_translated_tag( $category );
+										$term_object = mozilla_get_translated_tag( $category );
 										?>
-										<li class="tag"><?php echo esc_html( $term_name ); ?></li>
+										<li class="tag"><?php echo esc_html( $term_object->name ); ?></li>
 										<?php break; ?>
 									<?php endforeach; ?>
 								<?php endif; ?>


### PR DESCRIPTION
Per the Localization spreadsheet, I've updated the events filtering to use the tag IDs rather than their names, so it no longer breaks if they use special characters like &'s. I also updated the Country filter to use the Country code rather than the country name as it was breaking between languages

To test: 

- Filter events on the Events page by country and tag
- Toggle between languages
- Click on the tag within a single event to make sure it links to filtering properly
- This also effected event cards in groups, on the homepage and in campaign blocks