### PR TITLE
Transform tags on profiles to links

### DIFF
--- a/buddypress/members/single/profile.php
+++ b/buddypress/members/single/profile.php
@@ -585,9 +585,11 @@ if ( ( ! empty( $_SERVER['HTTPS'] ) && 'off' !== $_SERVER['HTTPS'] ) || ! empty(
 						}
 						?>
 						<?php if ( $found ) : ?>
-							<span class="profile__static-tag">
-								<?php echo esc_html( $temp_name ); ?>
-							</span>
+							<a href="<?php echo esc_url_raw( add_query_arg(array('tag' => $t->slug), get_home_url(null, 'people'))) ;?>" class="profile__static-tag">
+								<span>
+									<?php echo esc_html( $temp_name ); ?>
+								</span>
+							</a>
 						<?php endif; ?>
 					<?php endforeach; ?>
 				</div>

--- a/functions.php
+++ b/functions.php
@@ -228,7 +228,8 @@ add_filter( 'wpml_sl_blacklist_requests', 'wpml_sl_blacklist_requests', 10, 2 );
  * @param mixed $sitepress the current sitepress instance.
  */
 function wpml_sl_blacklist_requests( $blacklist, $sitepress ) {
-	$blacklist[] = '/events\/[a-zA-z]/';
+  $blacklist[] = '/events\/[a-zA-z]/';
+  $blacklist[] = '/.+/';
 	return $blacklist;
 }
 


### PR DESCRIPTION
This PR changes the tags on user profiles into links to the members directory with the corresponding filter applied. 

In response to this [GH Issue](https://github.com/mozilla/community-portal/issues/107)