### PR TITLE
disable email notifications

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -106,6 +106,7 @@ remove_action( 'em_event_save', 'bp_em_group_event_save', 1, 2 );
 remove_action( 'media_buttons', 'media_buttons' );
 
 // Filters.
+add_filter( 'send_email_change_email', '__return_false' );
 add_filter( 'nav_menu_link_attributes', 'mozilla_add_menu_attrs', 10, 3 );
 add_filter( 'nav_menu_css_class', 'mozilla_menu_class', 10, 4 );
 add_filter( 'em_get_countries', 'mozilla_add_online_to_countries', 10, 1 );


### PR DESCRIPTION
Disables email notifications called by wp_update_user as per 

https://codex.wordpress.org/Plugin_API/Filter_Reference/send_email_change_email

<img width="1179" alt="Screen Shot 2020-07-20 at 10 28 04 AM" src="https://user-images.githubusercontent.com/2521244/87949207-bed68100-ca73-11ea-8dd0-2dde09f0e952.png">
