### PR TITLE
Feature/truncate long links

### DIFF
--- a/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
+++ b/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
@@ -19,7 +19,7 @@
 			<?php if ( isset( $external_url ) && strlen( $external_url ) > 0 && filter_var( $external_url, FILTER_VALIDATE_URL ) ) : ?>
 				<div class="col-lg-12 col-md-6 col-sm-12">
 					<p class="events-single__label"><?php esc_html_e( 'Links', 'community-portal' ); ?></p>
-					<p><a href="<?php echo esc_url_raw( mozilla_verify_url( $external_url, false ) ); ?>" class="events-single__external-link"><?php echo esc_html( $external_url ); ?></a></p>
+					<p class="events-single__external-link-wrapper" title="<?php echo esc_html( $external_url ); ?>"><a href="<?php echo esc_url_raw( mozilla_verify_url( $external_url, false ) ); ?>" class="events-single__external-link"><?php echo esc_html( $external_url ); ?></a></p>
 				</div>
 				<?php
 			endif;

--- a/scss/_event-single.scss
+++ b/scss/_event-single.scss
@@ -625,4 +625,12 @@
             margin-right: 8px;
         }
     }
-}
+
+    &__external-link-wrapper {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: $color-blue-50;
+    }
+
+} // end .events-single


### PR DESCRIPTION
You can test this by editing an event and adding a very long external URL. 
Once the event is saved and the `event-single` page is viewed, the link should be truncated to a single line with an ellipsis. 
If you hover over the link, the full URL should appear. 
<img width="482" alt="Screen Shot 2020-07-20 at 12 42 08 PM" src="https://user-images.githubusercontent.com/10262636/87963318-82f8e700-ca86-11ea-8476-3a7c157eb10d.png">

