### PR TITLE
Clean up how redirects are handled and remove trailing slash 

### DIFF
--- a/buddypress/groups/single/group.php
+++ b/buddypress/groups/single/group.php
@@ -1573,7 +1573,7 @@
 								<span><?php esc_html_e( 'Preferred Language', 'community-portal' ); ?></span>
 								<div class="group__tags">
 									<div class="group__language">
-										<a href="/groups?language=<?php echo esc_attr( strtolower( $group_meta['group_language'] ) ); ?>" class="group__language-link"><?php echo esc_html( $languages[ strtolower( $group_meta['group_language'] ) ] ); ?></a>
+										<a href="<?php echo esc_url_raw( add_query_arg( array('language' => strtolower( $group_meta['group_language'] ) ),get_home_url( null, 'groups') ) ); ?>" class="group__language-link"><?php echo esc_html( $languages[ strtolower( $group_meta['group_language'] ) ] ); ?></a>
 									</div>
 								</div>
 							</div>

--- a/lib/language.php
+++ b/lib/language.php
@@ -26,22 +26,6 @@ function mozilla_wpml_redirect( $url ) {
 	}
 }
 
-
-/**
- * Verify trailing slash
- *
- * @param string $url URL to redirect.
- * @param string $language language code.
- */
-function verify_trailing_slash( $url, $language ) {
-
-	$language = $language . '/';
-	if ( false === stripos( $url, $language ) && ! isset( $_GET['page_id'] ) ) {
-		$url = preg_replace( '/(\b[a-zA-Z]{2}\b)/', '${1}/', $url );
-		mozilla_wpml_redirect( $url );
-	}
-}
-
 /**
  * Set the language
  *
@@ -75,13 +59,18 @@ function mozilla_match_browser_locale() {
 	if ( isset( $_SERVER['REQUEST_URI'] ) && function_exists('icl_get_languages') ) {
 		$url            = get_site_url( null, esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 		$wpml_languages = icl_get_languages( 'skip_missing=N&orderby=KEY&order=DIR&link_empty_to=str' );
-		preg_match( '/\b[a-zA-Z]{2}\b/', $url, $matches );
-		if ( wp_doing_ajax() || is_admin() || ( isset( $matches[0] ) && 'wp' === $matches[0] ) || isset( $_GET['action'] ) ) {
+		if (empty(ICL_LANGUAGE_CODE)) {
+			return;
+		}
+		$base_url = get_site_url(null, ICL_LANGUAGE_CODE ); 
+		if ( wp_doing_ajax() || is_admin() || isset( $_GET['action'] ) ) {
 			return;
 		}
 
-		if ( isset( $matches[0] ) && array_key_exists( $matches[0], $wpml_languages ) ) {
-			verify_trailing_slash( $url, $matches[0] );
+		if ( false !== stripos($url, $base_url) ) {
+			if (false === stripos($url, $base_url . '/' )) {
+				mozilla_wpml_redirect($base_url . '/');
+			}
 			return;
 		}
 		mozilla_check_language( $url, $wpml_languages );
@@ -117,12 +106,12 @@ function mozilla_get_translated_tag( $category ) {
 		if ( ! empty( $translation ) ) {
 			return (object) [
         'name' => $translation->name,
-        'id' => $translation->term_id,
-      ];
+		'id' => $translation->term_id,
+		];
 		}
-  }
+	}
 	return (object) [
     'name' => $category->name,
     'id' => $category->term_id,
-  ];
+	];
 }

--- a/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
+++ b/plugins/events-manager/templates/template-parts/event-single/event-sidebar.php
@@ -97,7 +97,7 @@
 			<div class="col-lg-12 col-md-6 col-sm-12">
 				<p class="events-single__label"><?php esc_html_e( 'Preferred Language', 'community-portal' ); ?></p>
 				<p>
-				<a href="/events/?language=<?php print esc_attr( $event_meta[0]->language ); ?>" class="events-single__langauge-link"><?php echo esc_html( $language ); ?></a>
+				<a href="<?php echo esc_url_raw(add_query_arg( array('language' => $event_meta[0]->language), get_home_url(null, 'events')))?>" class="events-single__langauge-link"><?php echo esc_html( $language ); ?></a>
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
This PR is in response to the item on the Localization spreadsheet that mentioned when clicking on the language link for Spanish within a group or event it takes you to the listing page but adds a trailing slash that breaks the filtering. 

This happened because Spanish is one of the active languages on the site so the redirection code was adding a trailing slash. I've updated the redirection code to be much more specific and updated language links in Events and Groups as neither URL had the language code so they were redirecting to the default language. 