### PR TITLE
Update member tag links not to use translated slug

### DIFF
--- a/buddypress/members/single/profile.php
+++ b/buddypress/members/single/profile.php
@@ -572,11 +572,13 @@ if ( ( ! empty( $_SERVER['HTTPS'] ) && 'off' !== $_SERVER['HTTPS'] ) || ! empty(
 								}
 								$temp_name = $t->name;
 								if ( strtolower( $temp_slug ) === strtolower( $loop_tag ) ) {
+									$t->slug = $temp_slug;
 									$found = true;
 									break;
 								}
 							} else {
 								$temp_name = $t->name;
+								$temp_slug = $t->slug;
 								if ( strtolower( $t->slug ) === strtolower( $loop_tag ) ) {
 									$found = true;
 									break;
@@ -585,7 +587,7 @@ if ( ( ! empty( $_SERVER['HTTPS'] ) && 'off' !== $_SERVER['HTTPS'] ) || ! empty(
 						}
 						?>
 						<?php if ( $found ) : ?>
-							<a href="<?php echo esc_url_raw( add_query_arg(array('tag' => $t->slug), get_home_url(null, 'people'))) ;?>" class="profile__static-tag">
+							<a href="<?php echo esc_url_raw( add_query_arg(array('tag' => $temp_slug), get_home_url(null, 'people'))) ;?>" class="profile__static-tag">
 								<span>
 									<?php echo esc_html( $temp_name ); ?>
 								</span>


### PR DESCRIPTION
This PR addresses the bug on the localization spreadsheet about tags on member profiles not linking properly. The issue was that on translated versions of the members page it was still using the untranslated slug for the tag as the filtering value instead of the translated one. This fix sets up the code to always use the untranslated slug.