### PR TITLE
add HTML elements to wp_kses in activity single

### DIFF
--- a/single-activity.php
+++ b/single-activity.php
@@ -146,6 +146,11 @@
 																'class' => array(),
 															),
 															'div' => array( 'class' => array() ),
+															'b'   => array(),
+															'i'   => array(),
+															'ul'  => array(),
+															'ol'  => array(),
+															'li'  => array(),
 														)
 													);
 													?>


### PR DESCRIPTION
A change last year switched to using wp_kses for a few things. This adds a few HTML elements to the approval list on one of the elements on the single activity page.